### PR TITLE
Fix for the double scrollbar issue

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -45,7 +45,7 @@
 						}
 
 						if (dialogsCount === 1) {
-							$body.unbind('keydown').removeClass('ngdialog-open');
+							$body.unbind('keydown');
 						}
 
 						dialogsCount -= 1;
@@ -54,10 +54,14 @@
 							$dialog.unbind(animationEndEvent).bind(animationEndEvent, function () {
 								$dialog.scope().$destroy();
 								$dialog.remove();
+								if (dialogsCount === 0)
+									$body.removeClass('ngdialog-open');
 							}).addClass('ngdialog-closing');
 						} else {
 							$dialog.scope().$destroy();
 							$dialog.remove();
+							if (dialogsCount === 0)
+								$body.removeClass('ngdialog-open');
 						}
 
 						$rootScope.$broadcast('ngDialog.closed', $dialog);


### PR DESCRIPTION
Remove the ngdialog-open class from the body after the hide transition has finished and the dialog has been removed from the DOM. Without this fix a double scrollbar will be displayed during the exit transition if both the dialog and the document have a scrollbar present.
