### PR TITLE
accommodate template being returned as array

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -106,6 +106,8 @@
 								template :
 								template.data && angular.isString(template.data) ?
 									template.data :
+									template[1] && angular.isString(template[1]) ?
+									template[1] :
 									'';
 
 							$templateCache.put(options.template, template);


### PR DESCRIPTION
the issue: opening the dialog, the template does not load the first time. Closing, then opening the dialog a second time, the template does load.

on opening the dialog:

```
ngDialog.open({ 
                      template: '/path/to/modals/addMember.html',
                      controller : 'addMember'
                    });
```

if a log my template above line 97, it is returned as an array, like so:

```
[200, "<form class="form-horizontal" name="newMemberForm"…ate> ... </form>", Object]
```

since template.data is not defined, my template is set to an empty string. Causing the first attempt to fetch the template to fail. Hence I've added a check for the above format which resolves the issue.

Perhaps this is because I'm using a different version of angular (1.2.15) ? In either case, I am submitting this for your consideration.
