### PR TITLE
Add an openModal() API method

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ app.controller('MainCtrl', function ($scope, ngDialog) {
 
 ngDialog service provides easy to use and minimalistic API, but in the same time it's powerful enough. Here is the list of accessible methods that you can use:
 
+##### Options:
+
+
 ### ``.open(options)``
 
 Method allows to open dialog window, creates new dialog instance on each call. It accepts ``options`` object as the only argument.
@@ -161,6 +164,34 @@ dialog.closePromise.then(function (data) {
 	console.log(data.id + ' has been dismissed.');
 });
 ```
+
+
+### ``.openModal(options)``
+
+Opens a dialog that by default does not close when hitting escape or clicking outside the dialog window. The function returns a promise that is either resolved or rejected depending on the way the dialog was closed.
+
+##### Options:
+
+The options are the same as the regular open() function, with an extra function added to the scope:
+
+##### ``scope.confirm()``
+
+In addition to the ``.closeThisDialog()`` method. The method ```.confirm()``` is also injected to passed ``$scope``. Use this method to close the dialog and ```resolve``` the promise that was returned when opening the modal.
+
+The function accepts a single optional parameter which is used as the value of the resolved promise.
+
+```html
+<div class="dialog-contents">
+	Some message
+	<button ng-click="closeThisDialog()">Cancel</button>
+	<button ng-click="confirm()">Confirm</button>
+</button>
+```
+
+#### Returns
+
+An Angular promise object that is resolved if the ```confirm()``` function is used to close the dialog, otherwise the promise is rejected.
+
 
 ### ``.close(id)``
 

--- a/example/index.html
+++ b/example/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html ng-app="exampleDialog">
 <head>
 	<meta charset="utf-8">
@@ -18,7 +18,7 @@
 		ng-dialog-controller="InsideCtrl"
 		ng-dialog-data="{{jsonData}}"
 		ng-dialog-class="ngdialog-theme-default"
-        ng-dialog-scope="this"
+		ng-dialog-scope="this"
 		ng-dialog-show-close="false">Open via directive</button>
 
 	<a href="" ng-click="openDefault()">Default theme</a>
@@ -26,13 +26,14 @@
 	<a href="" ng-click="openTemplate()">Open with external template for modal</a>
 	<a href="" ng-click="openTimed()">Open and use return value to close later</a>
 	<a href="" ng-click="openNotify()">Open and use promise to know when closed</a>
+	<a href="" ng-click="openModal()">Open modal</a>
 
 	<script type="text/ng-template" id="firstDialogId">
 		<div class="ngdialog-message">
 			<h3>ngDialog template</h3>
 			<p ng-show="theme">Test content for <code>{{theme}}</code></p>
 			<p ng-show="ngDialogData.foo">Data passed through directive: <code>{{ngDialogData.foo}}</code></p>
-            <p ng-show="dialogModel.message">Scope passed through directive: <code>{{dialogModel.message}}</code></p>
+			<p ng-show="dialogModel.message">Scope passed through directive: <code>{{dialogModel.message}}</code></p>
 		</div>
 		<div class="ngdialog-buttons">
 			<button type="button" class="ngdialog-button ngdialog-button-secondary"
@@ -46,6 +47,19 @@
 
 	<script type="text/ng-template" id="secondDialogId">
 		<h3><a href="" ng-click="closeSecond()">Close all by click here!</a></h3>
+	</script>
+
+	<script type="text/ng-template" id="modalDialogId">
+		<div class="ngdialog-message">
+			<h3>ngDialog modal example</h3>
+			<p>The openModal function returns a promise that is resolved when confirmed and rejected when otherwise closed.</p>
+			<p>Modal dialogs by default do not close when clicked outside the dialog or when hitting escape. This can ofcourse be overridden when opening the dialog.</p>
+			<p>Confirm can take a value. Enter one here for example and see the console output: <input ng-model="confirmValue" /></p>
+		</div>
+		<div class="ngdialog-buttons">
+			<button type="button" class="ngdialog-button ngdialog-button-primary" ng-click="confirm(confirmValue)">Confirm</button>
+			<button type="button" class="ngdialog-button ngdialog-button-secondary" ng-click="closeThisDialog()">Cancel</button>
+		</div>
 	</script>
 
 	<script src="../bower_components/angular/angular.min.js"></script>
@@ -66,6 +80,17 @@
 					template: 'firstDialogId',
 					controller: 'InsideCtrl',
 					className: 'ngdialog-theme-default'
+				});
+			};
+
+			$scope.openModal = function () {
+				ngDialog.openModal({
+					template: 'modalDialogId',
+					className: 'ngdialog-theme-default'
+				}).then(function (value) {
+					console.log('Modal promise resolved.', value);
+				}, function () {
+					console.log('Modal promise rejected.');
 				});
 			};
 
@@ -122,9 +147,9 @@
 		});
 
 		app.controller('InsideCtrl', function ($scope, ngDialog) {
-            $scope.dialogModel = {
-                message : 'message from passed scope'
-            };
+			$scope.dialogModel = {
+				message : 'message from passed scope'
+			};
 			$scope.openSecond = function () {
 				ngDialog.open({
 					template: '<h3><a href="" ng-click="closeSecond()">Close all by click here!</a></h3>',

--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -196,6 +196,51 @@
 					},
 
 					/*
+					 * @param {Object} options:
+					 * - template {String} - id of ng-template, url for partial, plain string (if enabled)
+					 * - plain {Boolean} - enable plain string templates, default false
+					 * - scope {Object}
+					 * - controller {String}
+					 * - className {String} - dialog theme class
+					 * - showClose {Boolean} - show close button, default true
+					 * - closeByEscape {Boolean} - default false
+					 * - closeByDocument {Boolean} - default false
+					 *
+					 * @return {Object} dialog
+					 */
+					openModal: function (opts) {
+						var defer = $q.defer();
+
+						// Set modal defaults
+						var options = {
+							closeByEscape: false,
+							closeByDocument: false
+						};
+						angular.extend(options, opts);
+						// Setup scope confirm function
+						options.scope = angular.isObject(options.scope) ? options.scope.$new() : $rootScope.$new();
+						options.scope.confirm = function (value) {
+							// If confirm is called, resolve the deferred
+							defer.resolve(value);
+							// And close the dialog
+							openResult.close();
+						};
+
+						// Open the dialog
+						var openResult = publicMethods.open(options);
+						openResult.closePromise.then(function () {
+							/* 
+								When the dialog is closed, reject the deferred. If the confirm function 
+								was used, the defer was already resolved and reject does nothing.
+							 */
+							defer.reject();
+						});
+
+						return defer.promise;
+					},
+
+
+					/*
 					 * @param {String} id
 					 * @return {Object} dialog
 					 */


### PR DESCRIPTION
Submitting this on behalf of @robbaman who built on top of the returned promise I added in my last PR. This adds an `.openModal(options)` call to the API which returns a promise which can be resolved when a `confirm()` function is called on the scope, or rejected if the dialog is closed in some other manner. It allows for a more natural flow control for modal style dialogs, without necessarily detracting from the simplicity if you want to just open a dialog.
