### PR TITLE
Prevent the document from jumping if a dialog is shown while the body has a scrollbar

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -29,7 +29,6 @@
 		this.$get = ['$document', '$templateCache', '$compile', '$q', '$http', '$rootScope', '$timeout', '$window',
 			function ($document, $templateCache, $compile, $q, $http, $rootScope, $timeout, $window) {
 				var $body = $document.find('body');
-				var systemScrollbarWidth;
 
 				var privateMethods = {
 					onDocumentKeydown: function (event) {
@@ -38,12 +37,10 @@
 						}
 					},
 
-					setBodyPadding: function () {
+					setBodyPadding: function (width) {
 						var originalBodyPadding = parseInt(($body.css('padding-right') || 0), 10)
-						if (systemScrollbarWidth || (systemScrollbarWidth = privateMethods.measureScrollbar())) {
-							$body.css('padding-right', (originalBodyPadding + systemScrollbarWidth) + 'px');
-							$body.data('ng-dialog-original-padding', originalBodyPadding);
-						}
+						$body.css('padding-right', (originalBodyPadding + width) + 'px');
+						$body.data('ng-dialog-original-padding', originalBodyPadding);
 					},
 
 					resetBodyPadding: function () {
@@ -53,21 +50,6 @@
 						} else {
 							$body.css('padding-right', '');
 						}
-					},
-
-					measureScrollbar: function () { 
-						var scrollDiv = $el('<div></div>');
-						scrollDiv.css('position', 'absolute');
-						scrollDiv.css('top', '-9999px');
-						scrollDiv.css('width', '50px');
-						scrollDiv.css('height', '50px');
-						scrollDiv.css('overflow', 'scroll');
-						$body.append(scrollDiv);
-
-						var scrollDivElem = scrollDiv[0];
-						var systemScrollbarWidth = scrollDivElem.offsetWidth - scrollDivElem.clientWidth;
-						scrollDiv.remove();
-						return systemScrollbarWidth;
 					},
 
 					closeDialog: function ($dialog) {
@@ -183,8 +165,9 @@
 								$compile($dialog)(scope);
 								var widthDiffs = $window.innerWidth - $body.prop('clientWidth');
 								$body.addClass('ngdialog-open');
-								if (widthDiffs != ($window.innerWidth - $body.prop('clientWidth'))) {
-									privateMethods.setBodyPadding();
+								var scrollBarWidth = widthDiffs - ($window.innerWidth - $body.prop('clientWidth'));
+								if (scrollBarWidth > 0) {
+									privateMethods.setBodyPadding(scrollBarWidth);
 								}
 								$body.append($dialog);
 							});


### PR DESCRIPTION
This change determines if the width of the document compared to the width of the window changes after applying the 'overflow: hidden' class. If so, the document must've had a scrollbar and a padding-right is applied to the body equal to the size of the width difference.

This prevents the content of the document from jumping slightly because of the changed body width (this effect is most noticably when the content is centered, which is not the case on the example page unfortunately).

Note that if a padding-right is already present on the body, the scrollbar padding is added when the dialog is shown and restored to the original value when the dialog is closed.
