### PR TITLE
Add ability to append the dialog to a DOM element other than the body

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -137,7 +137,7 @@
 						defers[self.latestID] = defer = $q.defer();
 
 						var scope = angular.isObject(options.scope) ? options.scope.$new() : $rootScope.$new();
-						var $dialog;
+						var $dialog, $dialogParent;
 
 						$q.when(loadTemplate(options.template)).then(function (template) {
 							template = angular.isString(template) ?
@@ -167,6 +167,13 @@
 								scope.ngDialogData = options.data.replace(/^\s*/, '')[0] === '{' ? angular.fromJson(options.data) : options.data;
 							}
 
+							if (options.id && angular.isString(options.id)) {
+								$dialogParent = angular.element(document.querySelector('#' + options.id));
+							}
+							else {
+								$dialogParent = $body;
+							}
+
 							scope.closeThisDialog = function() {
 								privateMethods.closeDialog($dialog);
 							};
@@ -180,7 +187,7 @@
 								if (scrollBarWidth > 0) {
 									privateMethods.setBodyPadding(scrollBarWidth);
 								}
-								$body.append($dialog);
+								$dialogParent.append($dialog);
 
 								$rootScope.$broadcast('ngDialog.opened', $dialog);
 							});


### PR DESCRIPTION
This is a relatively simple change that allows the dialog to be appended to a DOM element other than the body, by specifying the desired element's id as an extra option when calling ngDialog.open.

Please be aware that:
- There are still references to the $body element that should probably be changed to the new $dialogParent element instead, especially when doing styling manipulations. It worked OK _for us_, though, so we left that untouched.
- Didn't update the minified versions.
