### PR TITLE
close a dialog on location change fixes #95

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -23,6 +23,7 @@
 			showClose: true,
 			closeByDocument: true,
 			closeByEscape: true,
+			closeByNavigation: false,
 			appendTo: false,
 			preCloseCallback: false,
 			cache: true
@@ -259,6 +260,12 @@
 
 							if (options.closeByEscape) {
 								$body.bind('keydown', privateMethods.onDocumentKeydown);
+							}
+							
+							if (options.closeByNavigation) {
+								$rootScope.$on('$locationChangeSuccess', function () {
+									privateMethods.closeDialog($dialog);
+								});
 							}
 
 							closeByDocumentHandler = function (event) {


### PR DESCRIPTION
Optionally close a dialog when location is changed, e.g. a view is changed, but the dialog is attached to the main document body.

Testing of this was mainly done in a project with custom themes, I can supply a modified version of the example index.html if requried.
