### PR TITLE
Fix HammerJs integration

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -74,7 +74,10 @@
 						var id = $dialog.attr('id');
 
 						if (typeof window.Hammer !== 'undefined') {
-							window.Hammer($dialog[0]).off('tap', closeByDocumentHandler);
+							var hammerTime = angular.element($dialog).scope().hammerTime;
+							hammerTime.off('tap', closeByDocumentHandler);
+							hammerTime.destroy();
+							delete $dialog.scope().hammerTime;
 						} else {
 							$dialog.unbind('click');
 						}
@@ -263,7 +266,7 @@
 							if (options.closeByEscape) {
 								$body.bind('keydown', privateMethods.onDocumentKeydown);
 							}
-							
+
 							if (options.closeByNavigation) {
 								$rootScope.$on('$locationChangeSuccess', function () {
 									privateMethods.closeDialog($dialog);
@@ -280,7 +283,8 @@
 							};
 
 							if (typeof window.Hammer !== 'undefined') {
-								window.Hammer($dialog[0]).on('tap', closeByDocumentHandler);
+								var hammerTime = scope.hammerTime = window.Hammer($dialog[0]);
+								hammerTime.on('tap', closeByDocumentHandler);
 							} else {
 								$dialog.bind('click', closeByDocumentHandler);
 							}


### PR DESCRIPTION
made ngdialog retain the hammer manager, uses it in off close dialog method and destroys it after

It retains it by putting in a hammerTime field on the scope. This might not be the best approach but I didn't want to fully get across the source...

It does call `destroy` on the Manager when it closes the dialog and `delete`s it from the scope
#101
#98
