### PR TITLE
prevent the modal from closing if preCloseCallback returns a falsy value

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -154,7 +154,7 @@
 										return;
 									});
 								}
-							} else if (preCloseCallbackResult !== false) {
+							} else if (!preCloseCallbackResult) {
 								privateMethods.performCloseDialog($dialog, value);
 							}
 						} else {


### PR DESCRIPTION
Currently if `preCloseCallback` returns `false` then ngDialog will not close the modal.
Since JavaScript treats several things as "falsy" e.g. `false` or `undefined`, it is natural to prevent the modal from closing if the return value is falsy instead of only `false` values.
Thanks for reviewing this PR and thanks for this awesome library :smile: