### PR TITLE
Added accessibility improvements (keyboard focus management / ARIA attribute)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,50 @@ ngDialog.open({
 });
 ```
 
+##### ``trapFocus {Boolean}``
+
+When ``true``, ensures that the focused element remains within the dialog to conform to accessibility recommendations. Default value is ``true``
+
+##### ``preserveFocus {Boolean}``
+
+When ``true``, closing the dialog restores focus to the element that launched it. Designed to improve keyboard accessibility. Default value is ``true``
+
+##### ``ariaAuto {Boolean}``
+
+When ``true``, automatically selects appropriate values for any unspecified accessibility attributes. Default value is ``true``
+
+See [Accessibility](#Accessibility) for more information.
+
+##### ``ariaRole {String}``
+
+Specifies the value for the ``role`` attribute that should be applied to the dialog element. Default value is ``null`` (unspecified)
+
+See [Accessibility](#Accessibility) for more information.
+
+##### ``ariaLaballedById {String}``
+
+Specifies the value for the ``aria-labelledby`` attribute that should be applied to the dialog element. Default value is ``null`` (unspecified)
+
+If specified, the value is not validated against the DOM. See [Accessibility](#Accessibility) for more information.
+
+##### ``ariaLaballedBySelector {String}``
+
+Specifies the CSS selector for the element to be referenced by the ``aria-labelledby`` attribute on the dialog element. Default value is ``null`` (unspecified)
+
+If specified, the first matching element is used. See [Accessibility](#Accessibility) for more information.
+
+##### ``ariaDescribedById {String}``
+
+Specifies the value for the ``aria-describedby`` attribute that should be applied to the dialog element. Default value is ``null`` (unspecified)
+
+If specified, the value is not validated against the DOM. See [Accessibility](#Accessibility) for more information.
+
+##### ``ariaDescribedBySelector {String}``
+
+Specifies the CSS selector for the element to be referenced by the ``aria-describedby`` attribute on the dialog element. Default value is ``null`` (unspecified)
+
+If specified, the first matching element is used. See [Accessibility](#Accessibility) for more information.
+
 ===
 
 ### ``.setDefaults(options)``
@@ -364,6 +408,34 @@ $rootScope.$on('ngDialog.opened', function (e, $dialog) {
 ## Themes
 
 Currently _ngDialog_ contains two default themes that show how easily you can create your own. Check ``example`` folder for demonstration purposes.
+
+## Accessibility
+
+ngDialog supports accessible keyboard navigation via the ``trapFocus`` and ``preserveFocus`` options.
+
+The ``role``, ``aria-labelledby`` and ``aria-describedby`` attributes are also supported, and are rendered as follows.
+
+Dialog ``role`` attribute:
+
+* ``options.ariaRole``, if specified
+* "dialog" if ``options.ariaAuto`` is ``true`` and the dialog contains any focusable elements
+* "alertdialog" is ``options.ariaAuto`` is ``true`` and the dialog does *not* contain any focusable elements
+
+Dialog ``aria-labelledby`` attribute:
+
+* ``options.ariaLabelledById``, if specified
+* If ``options.ariaLabelledBySelector`` is specified, the first matching element will be found and assigned an id (if required) and that id will be used
+* If ``options.ariaAuto`` is ``true``, the first heading element in the dialog (h1-6) will be found and processed as per ``ariaLabelledBySelector``
+
+Dialog ``aria-describedby`` attribute:
+
+* ``options.ariaDescribedById``, if specified
+* If ``options.ariaDescribedBySelector`` is specified, the first matching element will be found and assigned an id (if required) and that id will be used
+* If ``options.ariaAuto`` is ``true``, the first content element in the dialog (article,section,p) will be found and processed as per ``ariaDescribedBySelector``
+
+Dialog Content ``role`` attribute:
+
+* Always assigned a value of "document"
 
 ## CDN
 

--- a/example/index.html
+++ b/example/index.html
@@ -24,6 +24,8 @@
 		button.ngdialog-button:focus {
 			border: solid black 1px !important;
 		}
+		
+		.ngdialog h2:focus { outline: none; }
 	</style>
 </head>
 

--- a/example/index.html
+++ b/example/index.html
@@ -15,6 +15,15 @@
 			color: #333;
 			margin-bottom: 10px;
 		}
+
+		/* The following 'important' styles are just here to show off trapFocus */
+		button.ngdialog-button {
+			border: solid transparent 1px !important;
+		}
+		
+		button.ngdialog-button:focus {
+			border: solid black 1px !important;
+		}
 	</style>
 </head>
 

--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -262,7 +262,11 @@
 						var autoFocusEl = dialogEl.querySelector('*[autofocus]');
 						if (autoFocusEl !== null) {
 							autoFocusEl.focus();
-							return;
+
+							if (document.activeElement === autoFocusEl)
+								return;
+
+							// Autofocus element might was display: none, so let's continue
 						}
 
 						var focusableElements = privateMethods.getFocusableElements($dialog);
@@ -273,9 +277,10 @@
 						}
 
 						// We need to focus something for the screen readers to notice the dialog
-						var contentElement = dialogEl.querySelector('h1,h2,h3,h4,h5,h6,p');
+						var contentElements = privateMethods.filterVisibleElements(dialogEl.querySelectorAll('h1,h2,h3,h4,h5,h6,p,span'));
 
-						if (contentElement) {
+						if (contentElements.length > 0) {
+							var contentElement = contentElements[0];
 							$el(contentElement).attr('tabindex', '0');
 							contentElement.focus();
 						}
@@ -284,7 +289,22 @@
 					getFocusableElements : function($dialog) {
 						var dialogEl = $dialog[0];
 
-						return dialogEl.querySelectorAll(focusableElementSelector);
+						var rawElements = dialogEl.querySelectorAll(focusableElementSelector);
+
+						return privateMethods.filterVisibleElements(rawElements);
+					},
+
+					filterVisibleElements: function(els) {
+						var visibleFocusableElements = [];
+
+						for (var i=0; i<els.length; i++) {
+							var el = els[i];
+
+							if (el.offsetWidth > 0 || el.offsetHeight > 0)
+								visibleFocusableElements.push(el);
+						}
+
+						return visibleFocusableElements;
 					},
 
 					getActiveDialog: function() {


### PR DESCRIPTION
I've added some improvements on the accessibility front, specifically around focus management and aria attributes.

The keyboard focus works across the examples (incuding the nested dialogs) and has been tested in IE 11/Chrome 40/Firefox 37 for browsers and Windows Narrator and NVDA for screen readers.

The updates to the readme (and lesser extent, the code) should describe the changes sufficiently, but I thought I'd discuss some details that could be deemed controversial.

Firstly, the keyboard focus support (specifically ``trapFocus``, which I've enabled by default) forces the first content element (eg. p tag) to be focusable if there aren't any actual-focusable elements. ~~This causes a focus rect to appear around it, which might cause some complains about styling (it can be disabled via CSS)~~ This has been resolved in the latest commit, but it forces `.css('outline','css')` on the element which might be controversial in its own right.

Secondly, I've defaulted ``ariaAuto`` to ``true``, which will automatically apply aria attributes based on the available content. It's possible this could conflict with users that have applied aria attributes in their dialog content.

In both cases, my justification is that the vast majority of developers won't look at the accessibility side of things. I'd rather force the minority of accessibility-friendly developers to disable the features and have improved accessibility for the majority.

Happy to discuss further.