### PR TITLE
Fix commonjs support for Browserify building

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -7,7 +7,7 @@
 (function (root, factory) {
     if (typeof module !== 'undefined' && module.exports) {
         // CommonJS
-        module.exports = factory(require('angular'));
+        module.exports = require('angular');
     } else if (typeof define === 'function' && define.amd) {
         // AMD
         define(['angular'], factory);


### PR DESCRIPTION
This could also fix #167. I have only tested with Browserify though. The call to factory() would cause the angular module to be an empty object, thus causing issues creating the ngDialog module. 

It should also be noted in the README that an alias of `angular/angular.js` to `angular` will be required for commonjs support as Angular does not have a main field specified in the package.json.

I would also recommend a patch release after this is merged in (most likely patch as I don't see any backwards compatibility issues, might have a webpack user test it).