### PR TITLE
fix modal closing on truthy values instead of falsy ones

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -154,7 +154,7 @@
 										return;
 									});
 								}
-							} else if (!preCloseCallbackResult) {
+							} else if (preCloseCallbackResult) {
 								privateMethods.performCloseDialog($dialog, value);
 							}
 						} else {


### PR DESCRIPTION
Pull request #165 did exactly the opposite of what it said in the description. Previously, the modal closed on all values *except* false, with #165 it closed on al falsy values *including* false. In my fix it's closing on truthy values again (so *preventing* close on falsy values)