### PR TITLE
Restrict box-sizing styling to ngDialog elements

### DIFF
--- a/css/ngDialog.css
+++ b/css/ngDialog.css
@@ -39,9 +39,9 @@
 }
 
 .ngdialog,
-.ngdialog *,
-.ngdialog *:before,
-.ngdialog *:after {
+.ngdialog > *,
+.ngdialog > *:before,
+.ngdialog > *:after {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;


### PR DESCRIPTION
It is undesirable for a specific control style to override the default styling values for elements that the control is not directly in charge of generating.  In this case, .ngDialog * styling changes all descendants within an ngDialog to use border-box sizing, including the user-defined contents placed inside an ngDialog.  The browser default value for box-sizing is content-box, so that will be the value developers expect when coding the contents of the dialog.  The control should not be altering default style values for dialog content elements, as it makes the contents of a dialog have an inconsistent styling starting point as the rest of the application.