### PR TITLE
Ability to dynamically define dialog width

### DIFF
--- a/css/ngDialog-theme-default.css
+++ b/css/ngDialog-theme-default.css
@@ -78,10 +78,8 @@
   font-size: 1.1em;
   line-height: 1.5em;
   margin: 0 auto;
-  max-width: 100%;
   padding: 1em;
   position: relative;
-  width: 450px;
 }
 
 .ngdialog.ngdialog-theme-default .ngdialog-close {

--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -48,7 +48,8 @@
 			ariaLabelledById: null,
 			ariaLabelledBySelector: null,
 			ariaDescribedById: null,
-			ariaDescribedBySelector: null
+			ariaDescribedBySelector: null,
+			dialogWidth: '450px'
 		};
 
 		this.setForceBodyReload = function (_useIt) {
@@ -414,10 +415,11 @@
 								template += '<div class="ngdialog-close"></div>';
 							}
 
+							var styleWidth = 'style="width:' + options.dialogWidth + ';"';
 							self.$result = $dialog = $el('<div id="ngdialog' + globalID + '" class="ngdialog"></div>');
 							$dialog.html((options.overlay ?
-								'<div class="ngdialog-overlay"></div><div class="ngdialog-content" role="document">' + template + '</div>' :
-								'<div class="ngdialog-content" role="document">' + template + '</div>'));
+								'<div class="ngdialog-overlay"></div><div class="ngdialog-content" role="document" ' + styleWidth + '>' + template + '</div>' :
+								'<div class="ngdialog-content" role="document" ' + styleWidth + '>' + template + '</div>'));
 
 							$dialog.data('$ngDialogOptions', options);
 


### PR DESCRIPTION
Not all dialogs are 450px wide. Now we can give it a specific width if we want.
This is backward compatible, since the given default is 450px, so nothing should break/change.