### PR TITLE
Example of using CSS width to adjust dialog's width

### DIFF
--- a/css/ngDialog-custom-width.css
+++ b/css/ngDialog-custom-width.css
@@ -1,0 +1,3 @@
+.ngdialog.ngdialog-theme-plain.custom-width .ngdialog-content {
+    width: 150px;
+}

--- a/example/index.html
+++ b/example/index.html
@@ -7,6 +7,7 @@
 	<link rel="stylesheet" href="../css/ngDialog.css">
 	<link rel="stylesheet" href="../css/ngDialog-theme-default.css">
 	<link rel="stylesheet" href="../css/ngDialog-theme-plain.css">
+    <link rel="stylesheet" href="../css/ngDialog-custom-width.css">
 
 	<style>
 		a, button {
@@ -41,6 +42,7 @@
 		ng-dialog-show-close="false">Open via directive</button>
 	<a href="" ng-click="openDefault()">Default theme</a>
 	<a href="" ng-click="openPlain()">Plain theme</a>
+    <a href="" ng-click="openPlainCustomWidth()">Plain theme with custom width</a>
 	<a href="" ng-click="openInlineController()">Inline controller</a>
 	<a href="" ng-click="openTemplate()">Open with external template for modal</a>
 	<a href="" ng-click="openTemplateNoCache()">Open with external template for modal (disabled cache)</a>
@@ -251,6 +253,17 @@
 					closeByDocument: false
 				});
 			};
+
+            $scope.openPlainCustomWidth = function () {
+                $rootScope.theme = 'ngdialog-theme-plain custom-width';
+
+                ngDialog.open({
+                    template: 'firstDialogId',
+                    controller: 'InsideCtrl',
+                    className: 'ngdialog-theme-plain custom-width',
+                    closeByDocument: false
+                });
+            };
 
 			$scope.openInlineController = function () {
 				$rootScope.theme = 'ngdialog-theme-plain';


### PR DESCRIPTION
This PR shows how to use CSS to adjust the dialog's width.