### PR TITLE
Ability to use controllerAs syntax to bind controller to template

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -676,7 +676,7 @@
                         template: attrs.ngDialog,
                         className: attrs.ngDialogClass || defaults.className,
                         controller: attrs.ngDialogController,
-                        controllerAs: attrs.ngDialogControllerAlias,
+                        controllerAs: attrs.ngDialogControllerAs,
                         scope: ngDialogScope,
                         data: attrs.ngDialogData,
                         showClose: attrs.ngDialogShowClose === 'false' ? false : (attrs.ngDialogShowClose === 'true' ? true : defaults.showClose),

--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -387,6 +387,7 @@
                      * - plain {Boolean} - enable plain string templates, default false
                      * - scope {Object}
                      * - controller {String}
+                     * - controllerAs {String}
                      * - className {String} - dialog theme class
                      * - showClose {Boolean} - show close button, default true
                      * - closeByEscape {Boolean} - default true
@@ -435,7 +436,13 @@
                             }
 
                             if (options.controller && (angular.isString(options.controller) || angular.isArray(options.controller) || angular.isFunction(options.controller))) {
-                                var controllerInstance = $controller(options.controller, {
+                                
+                                var ctrl = options.controller;
+                                if (options.controllerAs && angular.isString(options.controllerAs)) {
+                                    ctrl += ' as ' + options.controllerAs;
+                                }
+                                
+                                var controllerInstance = $controller(ctrl, {
                                     $scope: scope,
                                     $element: $dialog
                                 });
@@ -579,6 +586,7 @@
                      * - name {String}
                      * - scope {Object}
                      * - controller {String}
+                     * - controllerAs {String}
                      * - className {String} - dialog theme class
                      * - showClose {Boolean} - show close button, default true
                      * - closeByEscape {Boolean} - default false
@@ -668,6 +676,7 @@
                         template: attrs.ngDialog,
                         className: attrs.ngDialogClass || defaults.className,
                         controller: attrs.ngDialogController,
+                        controllerAs: attrs.ngDialogControllerAlias,
                         scope: ngDialogScope,
                         data: attrs.ngDialogData,
                         showClose: attrs.ngDialogShowClose === 'false' ? false : (attrs.ngDialogShowClose === 'true' ? true : defaults.showClose),


### PR DESCRIPTION
The controllerAs controller syntax is recommended as a best practice by many members of the AngularJS community. This is simply an implementation to allow that syntax to be utilized when specifying controllers to be bound to the template.