### PR TITLE
fixes bug with $templateCache usage

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -441,8 +441,6 @@
                             var template = setup.template,
                                 locals = setup.locals;
 
-                            $templateCache.put(options.template || options.templateUrl, template);
-
                             if (options.showClose) {
                                 template += '<div class="ngdialog-close"></div>';
                             }
@@ -605,7 +603,7 @@
                                 return loadTemplateUrl(tmpl, {cache: false});
                             }
 
-                            return $templateCache.get(tmpl) || loadTemplateUrl(tmpl, {cache: true});
+                            return loadTemplateUrl(tmpl, {cache: $templateCache});
                         }
                     },
 

--- a/tests/ngDialog.spec.js
+++ b/tests/ngDialog.spec.js
@@ -80,6 +80,29 @@ describe('ngDialog', function () {
     }));
   });
 
+  describe('with already cached template URL', function () {
+    var elm;
+    beforeEach(inject(function (ngDialog, $timeout, $document, $httpBackend, $compile, $rootScope) {
+      $httpBackend.whenGET('cached.html').respond('<div><p>some text {{1 + 1}}</p></div>');
+      $compile('<div><div ng-include src="\'cached.html\'"></div></div>')($rootScope);
+
+      $rootScope.$digest();
+      $httpBackend.flush();
+
+      var id = ngDialog.open({
+        templateUrl: 'cached.html'
+      }).id;
+
+      $timeout.flush();
+
+      elm = $document[0].getElementById(id);
+    }));
+
+    it('should have compiled the html', inject(function () {
+      expect(elm.textContent).toEqual('some text 2');
+    }));
+  });
+
   describe('controller instantiation', function () {
     var Ctrl;
     beforeEach(inject(function (ngDialog, $timeout, $q) {


### PR DESCRIPTION
$http does save more than just the template content to $templateCache. It's an object that also contains response code, etc.
ngDialog pushes only the template content to the same cache, which results in errors if the template has already been cached by the native mechanisms before. Also if after the template is loaded by ngDialog native template loading will fail.
Additionally setting the $http cache option to true (caching in default cache) and pushing the result into $templateCache leads to caching the template twice.