### PR TITLE
FEATURE: Add commonjs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,22 @@ You can download all necessary ngDialog files manually or install it with bower:
 bower install ngDialog
 ```
 
+Then add `ngDialog` as a dependency for your app:
+
+```javascript
+var app = angular.module('exampleApp', ['ngDialog']);
+```
+
 or npm:
 
 ```bash
 npm install ng-dialog
+```
+
+Then add `ngDialog` as a dependency for your app:
+
+```javascript
+var app = angular.module('exampleApp', [require('ngDialog')]);
 ```
 
 ## Usage
@@ -32,8 +44,6 @@ npm install ng-dialog
 You need only to include ``ngDialog.js`` and  ``ngDialog.css`` (as minimal setup) to your project and then you can start using ``ngDialog`` provider in your directives, controllers and services. For example in controllers:
 
 ```javascript
-var app = angular.module('exampleApp', ['ngDialog']);
-
 app.controller('MainCtrl', function ($scope, ngDialog) {
     $scope.clickToOpen = function () {
         ngDialog.open({ template: 'popupTmpl.html' });
@@ -390,7 +400,7 @@ An Angular promise object that is resolved if the ``.confirm()`` function is use
 
 ### ``.isOpen(id)``
 
-Method accepts dialog's ``id`` and returns a ``Boolean`` value indicating whether the specified dialog is open. 
+Method accepts dialog's ``id`` and returns a ``Boolean`` value indicating whether the specified dialog is open.
 
 ===
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./js/ngDialog');
+module.exports = 'ngDialog';

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.0",
   "homepage": "https://github.com/likeastore/ngDialog",
   "description": "Modal dialogs and popups provider for Angular.js applications",
-  "main": "./js/ngDialog.js",
+  "main": "./index.js",
   "scripts": {
     "test": "./node_modules/karma/bin/karma start --single-run --browsers PhantomJS"
   },


### PR DESCRIPTION
Have the angular modules export their module name so they can be used like so:

```js
angular.module('app', [
  require('angular-resource'),
  require('angular-touch'),
  require('ngDialog'),
  // ... etc
]);
```