### PR TITLE
bugfix: all keydown events were unbound

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -155,7 +155,7 @@
                         }
 
                         if (dialogsCount === 1) {
-                            $elements.body.unbind('keydown');
+                            $elements.body.unbind('keydown', privateMethods.onDocumentKeydown);
                         }
 
                         if (!$dialog.hasClass('ngdialog-closing')){


### PR DESCRIPTION
When the (last) dialog is closed, all other event handlers on the body are unregistered. If required I can create a codepen sample...