### PR TITLE
Ignore elements with tabindex=-1 when tabbing

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -330,7 +330,24 @@
 
                         var rawElements = dialogEl.querySelectorAll(focusableElementSelector);
 
-                        return privateMethods.filterVisibleElements(rawElements);
+                        // Ignore untabbable elements, ie. those with tabindex = -1
+                        var tabbableElements = privateMethods.filterTabbableElements(rawElements);
+
+                        return privateMethods.filterVisibleElements(tabbableElements);
+                    },
+
+                    filterTabbableElements: function (els) {
+                        var tabbableFocusableElements = [];
+
+                        for (var i = 0; i < els.length; i++) {
+                            var el = els[i];
+
+                            if ($el(el).attr('tabindex') !== '-1') {
+                                tabbableFocusableElements.push(el);
+                            }
+                        }
+
+                        return tabbableFocusableElements;
                     },
 
                     filterVisibleElements: function (els) {


### PR DESCRIPTION
Elements with tabindex="-1" should not be considered when tabbing through elements in the DOM: http://www.w3.org/html/wg/drafts/html/master/single-page.html#attr-tabindex

With this fix, the ngDialog tab behavior will correctly ignore elements with tabindex="-1".  Tested locally and verified the behavior.

Closes #281