### PR TITLE
Feature/coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
+# Directories
+/node_modules
+/bower_components
+/coverage
+
+# Files
 .DS_Store
-node_modules
-bower_components
 *.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
   - 0.10

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -10,66 +10,38 @@ if (testMinified) {
 
 module.exports = function(config) {
   config.set({
-
-    // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: '',
-
-
-    // frameworks to use
-    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
     frameworks: ['jasmine'],
-
-
-    // list of files / patterns to load in the browser
     files: [
       'bower_components/angular/angular.js',
       'bower_components/angular-mocks/angular-mocks.js',
       subject,
       'tests/ngDialog.spec.js'
     ],
-
-
-    // list of files to exclude
-    exclude: [
-    ],
-
-
-    // preprocess matching files before serving them to the browser
-    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
-    preprocessors: {
-    },
-
-
-    // test results reporter to use
-    // possible values: 'dots', 'progress'
-    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['dots'],
-
-
-    // web server port
     port: 9877,
-
-
-    // enable / disable colors in the output (reporters and logs)
     colors: true,
-
-
-    // level of logging
-    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
     logLevel: config.LOG_INFO,
-
-
-    // enable / disable watching file and executing tests whenever any file changes
     autoWatch: false,
+    browsers: ['PhantomJS'],
+    singleRun: false,
+    reporters: ['dots', 'coverage'],
+    preprocessors: {
+      'js/ngDialog.js': ['coverage']
+    },
+    plugins: [
+      'karma-phantomjs-launcher',
+      'karma-coverage',
+      'karma-jasmine'
+    ],
+    coverageReporter: {
+      reporters: [{
+        type: 'html',
+        subdir: 'report-html'
+      }, {
+        type: 'lcov',
+        subdir: 'report-lcov'
+      }]
+    }
 
-
-    // start these browsers
-    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: [],
-
-
-    // Continuous Integration mode
-    // if true, Karma captures browsers, runs the tests and exits
-    singleRun: false
   });
 };

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
   },
   "readmeFilename": "README.md",
   "license": "MIT",
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "angular": "^1.4.x",
     "grunt": "~0.4.2",
@@ -44,6 +43,7 @@
     "grunt-myth": "~0.1.0",
     "jasmine-core": "^2.2.0",
     "karma": "^0.12.31",
+    "karma-coverage": "^0.5.0",
     "karma-jasmine": "^0.3.5",
     "karma-phantomjs-launcher": "^0.1.4",
     "myth": "~0.1.6",


### PR DESCRIPTION
Added to https://codeclimate.com/github/likeastore/ngDialog.

Note that as I am not collaborator, I cannot add coverage metrics. Instructions here: http://docs.codeclimate.com/article/219-setting-up-test-coverage

Also has a PR scanner: https://codeclimate.com/changelog/55c402a3e30ba02b5d002e26

Badge: `[![Code Climate](https://codeclimate.com/github/likeastore/ngDialog/badges/gpa.svg)](https://codeclimate.com/github/likeastore/ngDialog)`