### PR TITLE
fix previous focus runtime error on IE 9 & 10 (at least)

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -150,7 +150,7 @@
                         }
 
                         var previousFocus = $dialog.data('$ngDialogPreviousFocus');
-                        if (previousFocus) {
+                        if (previousFocus && previousFocus.focus) {
                             previousFocus.focus();
                         }
 


### PR DESCRIPTION
On IE9 & IE10, giving back the focus to the previous focused element on closing a dialog throws an error when this `previousFocus` object was the document body or any object that might not have a `focus()` function.