### PR TITLE
repair a invalid loop on deactivateAll function.

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -102,8 +102,8 @@
                         $elements.body.off('keydown', privateMethods.onTrapFocusKeydown);
                     },
 
-                    deactivateAll: function () {
-                        angular.forEach(function(el) {
+                    deactivateAll: function (els) {
+                        angular.forEach(els,function(el) {
                             var $dialog = angular.element(el);
                             privateMethods.deactivate($dialog);
                         });


### PR DESCRIPTION
repair a invalid loop on deactivateAll function.
If don‘t repair, inactive dialog will respond onTrapFocusKeydown.
修复deactivateAll方法中错误的循环语句。如果不修复，非激化态的弹窗也会响应onTrapFocusKeydown
