### PR TITLE
closePromise doesn't receive value with Escape

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -730,7 +730,7 @@
                                 var topDialogId = openIdStack[openIdStack.length - 1];
                                 $dialog = $el(document.getElementById(topDialogId));
                                 if ($dialog.data('$ngDialogOptions').closeByEscape) {
-                                    privateMethods.closeDialog($dialog, value);
+                                    privateMethods.closeDialog($dialog, '$escape');
                                 }
                             } else {
                                 publicMethods.closeAll(value);


### PR DESCRIPTION
closePromise receive "undefined" data.value when pressing Enter to close dialog instead of "$escape" as "$document" or "$closeButton".