### PR TITLE
fixing harcoded configs overruling defaults on openConfirm

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -691,11 +691,9 @@
                      */
                     openConfirm: function (opts) {
                         var defer = $q.defer();
-
-                        var options = {
-                            closeByEscape: false,
-                            closeByDocument: false
-                        };
+                        var options = angular.copy(defaults);
+                        
+                        opts = opts || {};
                         angular.extend(options, opts);
 
                         options.scope = angular.isObject(options.scope) ? options.scope.$new() : $rootScope.$new();


### PR DESCRIPTION
The default-configs are not used on openConfirm - there are hardcoded configs directly in the method. The configs set by ngDialogProvider.setDefaults should be used instead.

Referencing https://github.com/likeastore/ngDialog/issues/370