### PR TITLE
Allow the ngDialog package in npm to expose css

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "homepage": "https://github.com/likeastore/ngDialog",
   "description": "Modal dialogs and popups provider for Angular.js applications",
   "main": "./js/ngDialog.js",
+  "style": "./css/ngDialog.css",
   "scripts": {
     "pretest": "npm install && bower install --allow-root",
     "test": "./node_modules/karma/bin/karma start --single-run --browsers PhantomJS",


### PR DESCRIPTION
Many modules in npm are starting to expose their css entry files in their package.json files. This allows tools like ``npm-css``, ``rework-npm``, and ``npm-less`` to import ngDialog CSS from the node_modules directory. 

Also this plays well with browserify plugins (like ``parcelify``) which helps in bundling CSS together from npm packages