### PR TITLE
A string object is formed directly. 

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -514,7 +514,7 @@
 
                             if (options.data && angular.isString(options.data)) {
                                 var firstLetter = options.data.replace(/^\s*/, '')[0];
-                                scope.ngDialogData = (firstLetter === '{' || firstLetter === '[') ? angular.fromJson(options.data) : options.data;
+                                scope.ngDialogData = (firstLetter === '{' || firstLetter === '[') ? angular.fromJson(options.data) : new String(options.data);
                                 scope.ngDialogData.ngDialogId = dialogID;
                             } else if (options.data && angular.isObject(options.data)) {
                                 scope.ngDialogData = options.data;


### PR DESCRIPTION
A string object is formed directly. Chrome browser doesn't return error, as well as other browsers like IE, Firefox.