### PR TITLE
Minimize the dialog

### DIFF
--- a/css/ngDialog-theme-default.css
+++ b/css/ngDialog-theme-default.css
@@ -294,4 +294,5 @@
     background-color: gray;
     opacity: 0.8;
     padding: 5px;
+    z-index:99999;
 }

--- a/css/ngDialog-theme-default.css
+++ b/css/ngDialog-theme-default.css
@@ -230,7 +230,6 @@
     background-color: gray;
     position: absolute;
     bottom: 0;
-    left: 10px;
     z-index: 999999;
     display: flex;
 }

--- a/css/ngDialog-theme-default.css
+++ b/css/ngDialog-theme-default.css
@@ -226,7 +226,7 @@
 .ngdialog-minimized {
     padding: 10px;
     padding-left: 15px;
-    min-width: 300px;
+    min-width: 200px;
     background-color: gray;
     position: absolute;
     bottom: 0;

--- a/css/ngDialog-theme-default.css
+++ b/css/ngDialog-theme-default.css
@@ -288,3 +288,10 @@
     text-align: right;
 	width: 8px;
 }
+
+.ngdialog-minimized-preview {    
+    position: absolute;
+    background-color: gray;
+    opacity: 0.8;
+    padding: 5px;
+}

--- a/css/ngDialog-theme-default.css
+++ b/css/ngDialog-theme-default.css
@@ -109,6 +109,39 @@
   color: #777;
 }
 
+.ngdialog.ngdialog-theme-default .ngdialog-minimize-btn {
+	border-radius: 5px;
+	cursor: pointer;
+	position: absolute;
+	right: 0;
+	top: 0;
+}
+
+.ngdialog.ngdialog-theme-default .ngdialog-minimize-btn:before {
+	background: transparent;
+	border-radius: 3px;
+	color: #bbb;
+	content: '_';
+	font-size: 22px;
+	font-weight: 400;
+	height: 30px;
+	line-height: 26px;
+	position: absolute;
+	right: 25px;
+	top: -3px;
+	width: 30px;
+}
+
+.ngdialog.ngdialog-theme-default .ngdialog-minimize-btn:hover:before,
+.ngdialog.ngdialog-theme-default .ngdialog-minimize-btn:active:before {
+  color: #777;
+}
+
+.ngdialog-minimized .ngdialog-maximize-btn:hover:before,
+.ngdialog-minimized .ngdialog-maximize-btn:active:before {
+  border: 2px solid #777;
+}
+
 .ngdialog.ngdialog-theme-default .ngdialog-message {
   margin-bottom: .5em;
 }
@@ -188,4 +221,71 @@
 .ngdialog.ngdialog-theme-default .ngdialog-button.ngdialog-button-secondary {
   background: #e0e0e0;
   color: #777;
+}
+
+.ngdialog-minimized {
+    padding: 10px;
+    padding-left: 15px;
+    min-width: 300px;
+    background-color: gray;
+    position: absolute;
+    bottom: 0;
+    left: 10px;
+    z-index: 999999;
+    display: flex;
+}
+
+.ngdialog-minimized .ngdialog-minimized-close {
+  border-radius: 5px;
+  cursor: pointer;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+.ngdialog-minimized .ngdialog-minimized-close:before {
+  background: transparent;
+  border-radius: 3px;
+  color: #bbb;
+  content: '\00D7';
+  font-size: 26px;
+  font-weight: 400;
+  height: 30px;
+  line-height: 26px;
+  position: absolute;
+  right: 3px;
+  text-align: center;
+  top: 3px;
+  width: 30px;
+}
+
+.ngdialog-minimized .ngdialog-minimized-close:hover:before,
+.ngdialog-minimized .ngdialog-minimized-close:active:before {
+  color: #777;
+}
+
+.ngdialog-minimized .ngdialog-minimized-title {
+    color: white;
+}
+
+.ngdialog-minimized .ngdialog-maximize-btn {
+	border-radius: 5px;
+	cursor: pointer;
+	position: absolute;
+	right: 0;
+	top: 0;
+}
+
+.ngdialog-minimized .ngdialog-maximize-btn:before {
+    content: '';
+	background: transparent;
+    border: 2px solid #bbb;
+	border-radius: 2px;
+	color: #bbb;
+	height: 8px;
+	position: absolute;
+	right: 35px;
+	top: 10px;
+    text-align: right;
+	width: 8px;
 }

--- a/example/index.html
+++ b/example/index.html
@@ -70,6 +70,7 @@
     <a href="" ng-click="openConfirmWithPreCloseCallbackOnScope()">Open confirm modal with pre-close callback on scope</a>
     <a href="" ng-click="openConfirmWithPreCloseCallbackInlinedWithNestedConfirm()">Open confirm modal with pre-close inlined with nested confirm.</a>
     <a href="" ng-click="openWithoutOverlay()">Open without overlay</a>
+    <a id="via-service" href="" ng-click="openWithMinifying()">Open with minifying</a>
 
     <!-- Templates -->
 
@@ -385,6 +386,14 @@
                     plain: true,
                     overlay: false
                 });
+            };
+            
+            $scope.openWithMinifying = function() {
+                var new_dialog = ngDialog.open({ id: 'fromAService', template: 'firstDialogId', controller: 'InsideCtrl', data: { foo: 'from a service' }, showMinimize: true, minimizedTitle: 'Test title' });
+                // example on checking whether created `new_dialog` is open
+                $timeout(function() {
+                    console.log(ngDialog.isOpen(new_dialog.id));
+                }, 2000)
             };
 
             $rootScope.$on('ngDialog.opened', function (e, $dialog) {

--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -45,7 +45,6 @@
             className: 'ngdialog-theme-default',
             disableAnimation: false,
             plain: false,
-            showMinimize: true,
             showClose: true,
             closeByDocument: true,
             closeByEscape: true,
@@ -61,7 +60,9 @@
             ariaLabelledById: null,
             ariaLabelledBySelector: null,
             ariaDescribedById: null,
-            ariaDescribedBySelector: null
+            ariaDescribedBySelector: null,
+            showMinimize: false,
+            minimizedTitle: 'none titled',
         };
 
         this.setForceHtmlReload = function (_useIt) {
@@ -517,11 +518,12 @@
                      * - controllerAs {String}
                      * - className {String} - dialog theme class
                      * - disableAnimation {Boolean} - set to true to disable animation
-                     * - showMinimize {Boolean} - show minimize button, default false
                      * - showClose {Boolean} - show close button, default true
                      * - closeByEscape {Boolean} - default true
                      * - closeByDocument {Boolean} - default true
                      * - preCloseCallback {String|Function} - user supplied function name/function called before closing dialog (if set)
+                     * - showMinimize {Boolean} - show minimize button, default false
+                     * - minimizedTitle {String} - Title for the minimized element, default is 'None titled'
                      * @return {Object} dialog
                      */
                     open: function (opts) {
@@ -708,7 +710,7 @@
                                 }
 
                                 if (isMinimizeBtn) {
-                                    publicMethods.minimize($dialog.attr('id'));
+                                    publicMethods.minimize($dialog.attr('id'), options.minimizedTitle);
                                 }
                             };
 
@@ -838,7 +840,7 @@
                         }
                     },
 
-                    minimize: function(id) {
+                    minimize: function(id, minimizedTitle) {
                         privateMethods.isMoreMinimizedElementsPossible();
                         
                         var $dialog = $el(document.getElementById(id));
@@ -847,9 +849,7 @@
 
                         privateMethods.hideDialog($dialog);
 
-                        var title = minimizedId;
-
-                        var titleElement = $el('<div class="ngdialog-minimized-title">' + title + '<div>');
+                        var titleElement = $el('<div class="ngdialog-minimized-title">' + minimizedTitle + '<div>');
 
                         var maximizeButton = $el('<div class="ngdialog-maximize-btn"></div>');
                         maximizeButton.bind('click', (event) => {
@@ -926,7 +926,9 @@
                         closeByDocument: attrs.ngDialogCloseByDocument === 'false' ? false : (attrs.ngDialogCloseByDocument === 'true' ? true : defaults.closeByDocument),
                         closeByEscape: attrs.ngDialogCloseByEscape === 'false' ? false : (attrs.ngDialogCloseByEscape === 'true' ? true : defaults.closeByEscape),
                         overlay: attrs.ngDialogOverlay === 'false' ? false : (attrs.ngDialogOverlay === 'true' ? true : defaults.overlay),
-                        preCloseCallback: attrs.ngDialogPreCloseCallback || defaults.preCloseCallback
+                        preCloseCallback: attrs.ngDialogPreCloseCallback || defaults.preCloseCallback,
+                        showMinimized: attrs.ngDialogShowMinimized === 'false' ? false : (attrs.ngDialogShowMinimized === 'true' ? true : defaults.showMinimized),
+                        minimizedTitle: attrs.ngDialogMinimizedTitle || defaults.minimizedTitle
                     });
                 });
             }

--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -503,6 +503,31 @@
                             alert("No more minimized is possible.");
                             return;
                         }
+                    },
+                    
+                    showMinimizedPreview: function(minimizedId, copiedPreviewContent) {
+                        var minimized = document.getElementById(minimizedId);
+                        var minimizedStyle = window.getComputedStyle(minimized);
+                        var minimizedLeftPosition = minimizedStyle.getPropertyValue('left');
+                        var minimizedWidth = minimized.offsetWidth;
+                        var minimizedHeight = minimized.offsetHeight;
+                        
+                        var previewContent = $el('<div>'+copiedPreviewContent+'</div>');
+                        previewContent.css({
+                            zoom: 0.5
+                        });
+                                                    
+                        var preview = $el('<div id="'+minimizedId+'-preview" class="ngdialog-minimized-preview"></div>');
+                        preview.css({
+                            bottom: minimizedHeight  + 'px',
+                            left: minimizedLeftPosition,
+                            width: (minimizedWidth-10)+'px'
+                        });
+                        
+                        preview.append(previewContent);
+                        
+                        var body = $el(document.body);
+                        body.append(preview);
                     }
                 };
 
@@ -850,15 +875,26 @@
                         privateMethods.hideDialog($dialog);
 
                         var titleElement = $el('<div class="ngdialog-minimized-title">' + minimizedTitle + '<div>');
+                        titleElement.bind('mouseover', function(event) {
+                            var dialog = document.getElementById(id);
+                            var copyDialogContent = dialog.getElementsByClassName('ngdialog-content')[0].innerHTML;
+                                                        
+                            privateMethods.showMinimizedPreview(minimizedId, copyDialogContent);
+                        });
+                        
+                        titleElement.bind('mouseout', function(event) {                            
+                            var mini = $el(document.getElementById(minimizedId+'-preview'));
+                            mini.remove();
+                        });
 
                         var maximizeButton = $el('<div class="ngdialog-maximize-btn"></div>');
-                        maximizeButton.bind('click', (event) => {
+                        maximizeButton.bind('click', function (event) {
                             privateMethods.closeMinimize(minimizedId);
                             privateMethods.showDialog($dialog);
                         });
 
                         var closeButton = $el('<div class="ngdialog-minimized-close"></div>');
-                        closeButton.bind('click', (event) => {
+                        closeButton.bind('click', function (event) {
                             privateMethods.closeDialog($dialog, '$closeButton');
                             privateMethods.closeMinimize(minimizedId);
                         });

--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -35,6 +35,7 @@
     var forceElementsReload = { html: false, body: false };
     var scopes = {};
     var openIdStack = [];
+    var openMinimizedIdStack = [];
     var keydownIsBound = false;
     var openOnePerName = false;
 
@@ -467,6 +468,20 @@
 
                         var $minimized = $el(minimizedElement);
                         $minimized.remove();
+
+                        openMinimizedIdStack.splice(openMinimizedIdStack.indexOf(minimizedId), 1);
+                        privateMethods.rearrangeMinimizedElements();
+                    },
+                    
+                    rearrangeMinimizedElements: function (){
+                        var leftPosition = 15;
+                        for(var i=0;i<openMinimizedIdStack.length; i++) {
+                            var minimized = $el(document.getElementById(openMinimizedIdStack[i]));
+                            minimized.css({
+                                left: leftPosition+"px"
+                            });
+                            leftPosition += 350;
+                        }
                     }
                 };
 
@@ -806,10 +821,11 @@
                     minimize: function(id) {
                         var $dialog = $el(document.getElementById(id));
                         var minimizedId = id + '-minimized';
+                        openMinimizedIdStack.push(minimizedId);
 
                         privateMethods.hideDialog($dialog);
 
-                        var title = 'TESTING!';
+                        var title = minimizedId;
 
                         var titleElement = $el('<div class="ngdialog-minimized-title">' + title + '<div>');
 
@@ -827,7 +843,13 @@
                             privateMethods.closeMinimize(minimizedId);
                         });
 
-                        var minimizedElement = $el('<div id="'+minimizedId+'" class="ngdialog-minimized"></div>');
+                        var minimizedElement = $el('<div id="' + minimizedId + '" class="ngdialog-minimized"></div>');
+                        if (openMinimizedIdStack.length > 1) {
+                            var leftPosition = 350 * (openMinimizedIdStack.length-1);
+                            minimizedElement.css({
+                                left: leftPosition+'px'
+                            });
+                        }
 
                         minimizedElement.append(titleElement);
                         minimizedElement.append(maximizeButton);

--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -505,16 +505,17 @@
                         }
                     },
                     
-                    showMinimizedPreview: function(minimizedId, copiedPreviewContent) {
+                    showMinimizedPreview: function(minimizedId, copiedPreviewContent, dialogcontentwidth) {
                         var minimized = document.getElementById(minimizedId);
                         var minimizedStyle = window.getComputedStyle(minimized);
                         var minimizedLeftPosition = minimizedStyle.getPropertyValue('left');
                         var minimizedWidth = minimized.offsetWidth;
                         var minimizedHeight = minimized.offsetHeight;
+                        var zoomlevel = ((minimizedWidth/dialogcontentwidth)*100)/100;
                         
                         var previewContent = $el('<div>'+copiedPreviewContent+'</div>');
                         previewContent.css({
-                            zoom: 0.5
+                            zoom: zoomlevel
                         });
                                                     
                         var preview = $el('<div id="'+minimizedId+'-preview" class="ngdialog-minimized-preview"></div>');
@@ -868,9 +869,13 @@
                     minimize: function(id, minimizedTitle) {
                         privateMethods.isMoreMinimizedElementsPossible();
                         
-                        var $dialog = $el(document.getElementById(id));
+                        var dialogElement = document.getElementById(id);
+                        var $dialog = $el(dialogElement);
                         var minimizedId = id + '-minimized';                        
                         openMinimizedIdStack.push(minimizedId);
+                        
+                        // save the width of the dialog content before hiding it
+                        var dialogContentWidth = dialogElement.getElementsByClassName('ngdialog-content')[0].offsetWidth
 
                         privateMethods.hideDialog($dialog);
 
@@ -879,7 +884,7 @@
                             var dialog = document.getElementById(id);
                             var copyDialogContent = dialog.getElementsByClassName('ngdialog-content')[0].innerHTML;
                                                         
-                            privateMethods.showMinimizedPreview(minimizedId, copyDialogContent);
+                            privateMethods.showMinimizedPreview(minimizedId, copyDialogContent, dialogContentWidth);
                         });
                         
                         titleElement.bind('mouseout', function(event) {                            

--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -475,17 +475,32 @@
                     
                     rearrangeMinimizedElements: function (){
                         var leftPosition = 0;
-                        for(var i=0;i<openMinimizedIdStack.length; i++) {
+                        for(var i=0;i<openMinimizedIdStack.length; i++) {                            
                             var minimized = $el(document.getElementById(openMinimizedIdStack[i]));
+                            var elementWidth = minimized[0].offsetWidth;
                             
                             minimized.css({
                                 left: leftPosition+"px"
                             });
                             
-                            var elementWidth = minimized[0].offsetWidth;
-                            var marginBetweenMinimizedElements = 25; 
-                            
-                            leftPosition += elementWidth + marginBetweenMinimizedElements;
+                            leftPosition += elementWidth + privateMethods.getMarginBetweenMinimizedElements();
+                        }
+                    },
+                    
+                    getMarginBetweenMinimizedElements: function() {
+                        return 25;
+                    },
+                    
+                    isMoreMinimizedElementsPossible: function() {                        
+                        var windowWidth = window.innerWidth;
+                        var elementWidth = document.getElementsByClassName('ngdialog-minimized').length > 0 ? 
+                                           document.getElementsByClassName('ngdialog-minimized')[0].offsetWidth : 0;
+                                           
+                        var currentLeftStartPosition = (elementWidth + privateMethods.getMarginBetweenMinimizedElements()) * openMinimizedIdStack.length;
+                        
+                        if ((currentLeftStartPosition+elementWidth) > windowWidth) {
+                            alert("No more minimized is possible.");
+                            return;
                         }
                     }
                 };
@@ -824,8 +839,10 @@
                     },
 
                     minimize: function(id) {
+                        privateMethods.isMoreMinimizedElementsPossible();
+                        
                         var $dialog = $el(document.getElementById(id));
-                        var minimizedId = id + '-minimized';
+                        var minimizedId = id + '-minimized';                        
                         openMinimizedIdStack.push(minimizedId);
 
                         privateMethods.hideDialog($dialog);
@@ -835,14 +852,12 @@
                         var titleElement = $el('<div class="ngdialog-minimized-title">' + title + '<div>');
 
                         var maximizeButton = $el('<div class="ngdialog-maximize-btn"></div>');
-
                         maximizeButton.bind('click', (event) => {
                             privateMethods.closeMinimize(minimizedId);
                             privateMethods.showDialog($dialog);
                         });
 
                         var closeButton = $el('<div class="ngdialog-minimized-close"></div>');
-
                         closeButton.bind('click', (event) => {
                             privateMethods.closeDialog($dialog, '$closeButton');
                             privateMethods.closeMinimize(minimizedId);

--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -501,8 +501,9 @@
                         
                         if ((currentLeftStartPosition+elementWidth) > windowWidth) {
                             alert("No more minimized is possible.");
-                            return;
+                            return false;
                         }
+                        return true;
                     },
                     
                     showMinimizedPreview: function(minimizedId, copiedPreviewContent, dialogcontentwidth) {
@@ -867,7 +868,8 @@
                     },
 
                     minimize: function(id, minimizedTitle) {
-                        privateMethods.isMoreMinimizedElementsPossible();
+                        if (!privateMethods.isMoreMinimizedElementsPossible())
+                            return;
                         
                         var dialogElement = document.getElementById(id);
                         var $dialog = $el(dialogElement);

--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -474,13 +474,18 @@
                     },
                     
                     rearrangeMinimizedElements: function (){
-                        var leftPosition = 15;
+                        var leftPosition = 0;
                         for(var i=0;i<openMinimizedIdStack.length; i++) {
                             var minimized = $el(document.getElementById(openMinimizedIdStack[i]));
+                            
                             minimized.css({
                                 left: leftPosition+"px"
                             });
-                            leftPosition += 350;
+                            
+                            var elementWidth = minimized[0].offsetWidth;
+                            var marginBetweenMinimizedElements = 25; 
+                            
+                            leftPosition += elementWidth + marginBetweenMinimizedElements;
                         }
                     }
                 };
@@ -844,18 +849,13 @@
                         });
 
                         var minimizedElement = $el('<div id="' + minimizedId + '" class="ngdialog-minimized"></div>');
-                        if (openMinimizedIdStack.length > 1) {
-                            var leftPosition = 350 * (openMinimizedIdStack.length-1);
-                            minimizedElement.css({
-                                left: leftPosition+'px'
-                            });
-                        }
 
                         minimizedElement.append(titleElement);
                         minimizedElement.append(maximizeButton);
                         minimizedElement.append(closeButton);
                         
                         $elements.body.append(minimizedElement);
+                        privateMethods.rearrangeMinimizedElements();
                     },
 
                     getOpenDialogs: function() {


### PR DESCRIPTION
This ads an option to minimize the dialog to the lower left corner of the browser. Adding severale minimized elements will place them horisontal right beside each other. There is a title to the left and two icons to the right on the minimized element. One icon to maximize the dialog again and one to close the minimized element plus the containing dialog. Moving the cursor over the title of the minimized element will show a preview of the content of the minimized dialog.
