### PR TITLE
Add height 100% to body when dialog is open

### DIFF
--- a/css/ngDialog.css
+++ b/css/ngDialog.css
@@ -111,4 +111,5 @@
 html.ngdialog-open,
 body.ngdialog-open {
   overflow: hidden;
+  height: 100%;
 }


### PR DESCRIPTION
I had an issue where the height of my body would be less than that of the viewport (and so content would get cut off), when the dialog was open.

Before picture: http://i.imgur.com/H2ES8kd.png
After my fix: http://i.imgur.com/i1UJk3I.png