### PR TITLE
Fixes #434: Added appendClassName method

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,24 @@ Note: If the className is not mentioned, the dialog will not display correctly.
 
 Check [themes](https://github.com/likeastore/ngDialog#themes) block to learn more.
 
+##### ``appendClassName {String}``
+
+Unlike the `className` property, which overrides any default classes specified through the `setDefaults()` method ([see docs](https://github.com/likeastore/ngDialog#setdefaultsoptions)), `appendClassName` allows for the addition of a class on top of any defaults.
+
+For example, the following would add both the `ngdialog-theme-default` and `ngdialog-custom` classes to the dialog opened:
+
+```javascript
+ngDialogProvider.setDefaults({
+    className: 'ngdialog-theme-default'
+});
+```
+```javascript
+ngDialog.open({
+    template: 'template.html',
+    appendClassName: 'ngdialog-custom'
+});
+```
+
 ##### ``disableAnimation {Boolean}``
 
 If ``true`` then animation for the dialog will be disabled, default ``false``.

--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -42,6 +42,7 @@
     m.provider('ngDialog', function () {
         var defaults = this.defaults = {
             className: 'ngdialog-theme-default',
+            appendClassName: '',
             disableAnimation: false,
             plain: false,
             showClose: true,
@@ -456,6 +457,7 @@
                      * - controller {String}
                      * - controllerAs {String}
                      * - className {String} - dialog theme class
+                     * - appendClassName {String} - dialog theme class to be appended to defaults
                      * - disableAnimation {Boolean} - set to true to disable animation
                      * - showClose {Boolean} - show close button, default true
                      * - closeByEscape {Boolean} - default true
@@ -526,6 +528,10 @@
 
                             if (options.className) {
                                 $dialog.addClass(options.className);
+                            }
+
+                            if (options.appendClassName) {
+                                $dialog.addClass(options.appendClassName);
                             }
 
                             if (options.disableAnimation) {
@@ -697,6 +703,7 @@
                      * - controller {String}
                      * - controllerAs {String}
                      * - className {String} - dialog theme class
+                     * - appendClassName {String} - dialog theme class to be appended to defaults
                      * - showClose {Boolean} - show close button, default true
                      * - closeByEscape {Boolean} - default false
                      * - closeByDocument {Boolean} - default false
@@ -814,6 +821,7 @@
                     ngDialog.open({
                         template: attrs.ngDialog,
                         className: attrs.ngDialogClass || defaults.className,
+                        appendClassName: attrs.ngDialogAppendClass,
                         controller: attrs.ngDialogController,
                         controllerAs: attrs.ngDialogControllerAs,
                         bindToController: attrs.ngDialogBindToController,

--- a/tests/unit/ngDialog.js
+++ b/tests/unit/ngDialog.js
@@ -105,6 +105,21 @@ describe('ngDialog', function () {
     }));
   });
 
+  describe('with an appended class', function () {
+    var elm;
+    beforeEach(inject(function (ngDialog, $timeout, $document) {
+      var id = ngDialog.open({
+        appendClassName: 'ngdialog-custom'
+      }).id;
+      $timeout.flush();
+      elm = $document[0].getElementById(id);
+    }));
+
+    it('should have the additional class', inject(function () {
+      expect(elm.className.split(' ')).toContain('ngdialog-custom');
+    }));
+  });
+
   describe('controller instantiation', function () {
     var Ctrl;
     beforeEach(inject(function (ngDialog, $timeout, $q) {


### PR DESCRIPTION
Fixes issue #434 

Pretty self explanatory - since specifying `className` on `ngDialog.open()` overrides any defaults set on the provider, I've added an additional property called `appendClassName` that simply adds the class to any existing defaults.

The property is equally available via the directive as the `ngDialogAppendClass` attribute, inline with the naming of the `className` property as `ngDialogClass`.

The README has been updated with documentation for the new property.

No additional examples or unit tests were added due to the simplicity of the property and the lack of current unit tests on even the `className` property. I'm happy to add examples/unit tests for the new property if need be.

Cheers!