### PR TITLE
correct merging custom data with data set in setDefauls

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -480,6 +480,13 @@
                         dialogID = dialogID || 'ngdialog' + localID;
                         openIdStack.push(dialogID);
 
+                        if (typeof options.data !== 'undefined') {
+                            if (typeof opts.data === 'undefined') {
+                                opts.data = {};
+                            }
+                            opts.data = angular.merge(angular.copy(options.data), opts.data);
+                        }
+
                         angular.extend(options, opts);
 
                         var defer;
@@ -717,6 +724,14 @@
                         var options = angular.copy(defaults);
 
                         opts = opts || {};
+
+                        if (typeof options.data !== 'undefined') {
+                            if (typeof opts.data === 'undefined') {
+                                opts.data = {};
+                            }
+                            opts.data = angular.merge(angular.copy(options.data), opts.data);
+                        }
+
                         angular.extend(options, opts);
 
                         options.scope = angular.isObject(options.scope) ? options.scope.$new() : $rootScope.$new();

--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -480,6 +480,7 @@
                         dialogID = dialogID || 'ngdialog' + localID;
                         openIdStack.push(dialogID);
 
+                        // Merge opts.data with predefined via setDefaults
                         if (typeof options.data !== 'undefined') {
                             if (typeof opts.data === 'undefined') {
                                 opts.data = {};
@@ -725,6 +726,7 @@
 
                         opts = opts || {};
 
+                        // Merge opts.data with predefined via setDefaults
                         if (typeof options.data !== 'undefined') {
                             if (typeof opts.data === 'undefined') {
                                 opts.data = {};


### PR DESCRIPTION
Hi, I'm using ngDialog in my app to handle a bunch of confirm dialogs, that share one template and bind data using ngDialogData.
Tried to use `setDefaults({data : ... })` to set some default values. But when I try to pass some custom data to `openConfirm({data : { smthng }})`, the default data object is totaly replaced, because of the angular.extend works (`angular.extend(options, opts);`)