### PR TITLE
Setting the width through a property js

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,30 @@ Specifies the CSS selector for the element to be referenced by the ``aria-descri
 
 If specified, the first matching element is used. See [Accessibility](#Accessibility) for more information.
 
+##### ``width {Number | String}``
+
+This option allows you to control the dialog's width. Default value is `null` (unspecified)
+
+If you provide a number 'px' metric will be used, on the other hand you are able to provide a specific metric using String like `'40%'`
+
+For example, the following will add `width: 400px;` to the dialog opened:
+
+```
+ngDialog.open({
+    template: 'template.html',
+    width: 400
+});
+```
+
+In another example, the following will add `width: 40%;`:
+
+```
+ngDialog.open({
+    template: 'template.html',
+    width: '40%'
+});
+```
+
 #### Returns:
 
 The ``open()`` method returns an object with some useful properties.

--- a/README.md
+++ b/README.md
@@ -376,9 +376,9 @@ If specified, the first matching element is used. See [Accessibility](#Accessibi
 
 This option allows you to control the dialog's width. Default value is `null` (unspecified)
 
-If you provide a number 'px' metric will be used, on the other hand you are able to provide a specific metric using String like `'40%'`
+If you provide a Number, 'px' will be appended. To use a custom metric, use a String, e.g. `'40%'`.
 
-For example, the following will add `width: 400px;` to the dialog opened:
+For example, the following will add `width: 400px;` to the dialog when opened:
 
 ```
 ngDialog.open({

--- a/example/index.html
+++ b/example/index.html
@@ -70,6 +70,7 @@
     <a href="" ng-click="openConfirmWithPreCloseCallbackOnScope()">Open confirm modal with pre-close callback on scope</a>
     <a href="" ng-click="openConfirmWithPreCloseCallbackInlinedWithNestedConfirm()">Open confirm modal with pre-close inlined with nested confirm.</a>
     <a href="" ng-click="openWithoutOverlay()">Open without overlay</a>
+    <a href="" ng-click="openWithJSSpecificWidth()" id="js-width">Open with js specific width</a>
 
     <!-- Templates -->
 
@@ -384,6 +385,15 @@
                     className: 'ngdialog-theme-default',
                     plain: true,
                     overlay: false
+                });
+            };
+
+            $scope.openWithJSSpecificWidth = function () {
+                ngDialog.open({
+                    template: '<h2>Notice that style inline set specific width!</h2>',
+                    className: 'ngdialog-theme-default',
+                    width: 650,
+                    plain: true
                 });
             };
 

--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -545,7 +545,11 @@
 
                             if (options.width) {
                                 var $dialogContent = $dialog[0].querySelector('.ngdialog-content');
-                                (angular.isString(options.width)) ? $dialogContent.style.width = options.width : $dialogContent.style.width = options.width + 'px';
+                                if (angular.isString(options.width)) {
+                                    $dialogContent.style.width = options.width;
+                                } else {
+                                    $dialogContent.style.width = options.width + 'px';
+                                }
                             }
 
                             if (options.disableAnimation) {

--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -61,7 +61,8 @@
             ariaLabelledBySelector: null,
             ariaDescribedById: null,
             ariaDescribedBySelector: null,
-            bodyClassName: 'ngdialog-open'
+            bodyClassName: 'ngdialog-open',
+            width: null
         };
 
         this.setForceHtmlReload = function (_useIt) {
@@ -540,6 +541,10 @@
 
                             if (options.appendClassName) {
                                 $dialog.addClass(options.appendClassName);
+                            }
+
+                            if (options.width) {
+                                $dialog[0].querySelector('.ngdialog-content').style.width = options.width + 'px';
                             }
 
                             if (options.disableAnimation) {

--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -544,7 +544,8 @@
                             }
 
                             if (options.width) {
-                                $dialog[0].querySelector('.ngdialog-content').style.width = options.width + 'px';
+                                var $dialogContent = $dialog[0].querySelector('.ngdialog-content');
+                                (angular.isString(options.width)) ? $dialogContent.style.width = options.width : $dialogContent.style.width = options.width + 'px';
                             }
 
                             if (options.disableAnimation) {

--- a/tests/protractor/open.js
+++ b/tests/protractor/open.js
@@ -14,4 +14,9 @@ describe('ngDialog open', function() {
         expect(text).toBe('Data passed through: from a service');
       });
   });
+
+  it('should define specific width through a property js', function() {
+    element(by.css('#js-width')).click();
+    expect(element(by.css('.ngdialog-content')).getCssValue('width')).toBe('650px');
+  });
 });

--- a/tests/unit/ngDialog.js
+++ b/tests/unit/ngDialog.js
@@ -267,4 +267,27 @@ describe('ngDialog', function () {
       });
   });
 
+  describe('with an width', function () {
+    var elm, open;
+    beforeEach(inject(function (ngDialog, $timeout, $document) {
+      open = function(width) {
+        var id = ngDialog.open({
+          width: width
+        }).id;
+        $timeout.flush();
+        elm = $document[0].getElementById(id).querySelector('.ngdialog-content');
+      }
+    }));
+
+    it('should transform number to px', function () {
+      open(400);
+      expect(elm.style.cssText).toBe('width: 400px; ');
+    });
+
+    it('should set other width metrics', function () {
+      open('40%');
+      expect(elm.style.cssText).toBe('width: 40%; ');
+    });
+  });
+
 });


### PR DESCRIPTION
Sometimes is useful put specific width through js property because dont need put any css class every single time you need a specific width. I believe this can help us.

Readme:

<img width="1004" alt="captura de tela 2016-05-03 as 08 48 07" src="https://cloud.githubusercontent.com/assets/5859119/14982331/f7685406-110b-11e6-8ba8-89f7e7dd14e3.png">



https://github.com/likeastore/ngDialog/issues/222