### PR TITLE
Fix controllerIntance in angular 1.2

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -612,7 +612,11 @@
                                     angular.extend(controllerInstance.instance, {ngDialogId: scope.ngDialogId, ngDialogData: scope.ngDialogData, closeThisDialog: scope.closeThisDialog});
                                 }
 
-                                $dialog.data('$ngDialogControllerController', controllerInstance());
+                                if(typeof controllerInstance === 'function'){
+                                    $dialog.data('$ngDialogControllerController', controllerInstance());
+                                } else {
+                                    $dialog.data('$ngDialogControllerController', controllerInstance);
+                                }
                             }
 
                             $timeout(function () {


### PR DESCRIPTION
In Angular 1.2 when execute ngDialog.open with controller parameter, the component crasch.
In Chrome console show this message:
![screenshot from 2016-05-12 14-56-42](https://cloud.githubusercontent.com/assets/6430518/15225394/ad0c09f2-1854-11e6-9232-be10420a0a77.png)

This error occurs because the variable controllerIntance is Json Object in Angular 1.2 but in Angular 1.3 is a function.

**Related issues**
#467 

