### PR TITLE
Fixed ngDialog closeByNavigation to be cancellable if preCloseCallback returns false

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -218,16 +218,20 @@
                                 if (preCloseCallbackResult.closePromise) {
                                     preCloseCallbackResult.closePromise.then(function () {
                                         privateMethods.performCloseDialog($dialog, value);
+                                    }, function () {
+                                        return false;
                                     });
                                 } else {
                                     preCloseCallbackResult.then(function () {
                                         privateMethods.performCloseDialog($dialog, value);
                                     }, function () {
-                                        return;
+                                        return false;
                                     });
                                 }
                             } else if (preCloseCallbackResult !== false) {
                                 privateMethods.performCloseDialog($dialog, value);
+                            } else {
+                                return false;
                             }
                         } else {
                             privateMethods.performCloseDialog($dialog, value);
@@ -441,9 +445,9 @@
 
                     getRouterLocationEventName: function() {
                         if(privateMethods.detectUIRouter()) {
-                            return '$stateChangeSuccess';
+                            return '$stateChangeStart';
                         }
-                        return '$locationChangeSuccess';
+                        return '$locationChangeStart';
                     }
                 };
 
@@ -653,8 +657,9 @@
 
                             if (options.closeByNavigation) {
                                 var eventName = privateMethods.getRouterLocationEventName();
-                                $rootScope.$on(eventName, function () {
-                                    privateMethods.closeDialog($dialog);
+                                $rootScope.$on(eventName, function ($event) {
+                                    if (privateMethods.closeDialog($dialog) === false)
+                                        $event.preventDefault();
                                 });
                             }
 


### PR DESCRIPTION
**What issue is this PR resolving? Alternatively, please describe the bugfix/enhancement this PR aims to provide**
When using ``closeByNavigation`` on a ngDialog, it is suppose to close the dialog when you change navigation states (e.g. use the browser back button).

The ``preCloseCallback`` allows the close action to be cancellable (e.g. confirm closing dialog will delete unsaved changes and cancel the close if user chooses cancel).

However using the ``closeByNavigation`` combined with the ``preCloseCallback``, it does not correctly stop the navigation event from happening even though the dialog did not close.

The ``$location`` ``$locationChangeStart`` event allows the location change event to be cancelled so the browser remains on the current location/route/state.

This PR changes the ``closeByNavigation`` to use the ``$locationChangeStart`` event instead of the ``$locationChangeSuccess`` event and appropriate cancels the location change if the ``preCloseCallback`` returned false.

**Have you provided unit tests that either prove the bugfix or cover the enhancement?**
No

**Related issues**
Not sure