### PR TITLE
Solve a problem with Accept-header. Set it as 'text/html' instead of 'a…

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -707,8 +707,13 @@
                         };
 
                         function loadTemplateUrl (tmpl, config) {
+                            var config = config || {};
+                            config.headers = config.headers || {};
+
+                            angular.extend(config.headers, {'Accept': 'text/html'});
+
                             $rootScope.$broadcast('ngDialog.templateLoading', tmpl);
-                            return $http.get(tmpl, (config || {})).then(function(res) {
+                            return $http.get(tmpl, config).then(function(res) {
                                 $rootScope.$broadcast('ngDialog.templateLoaded', tmpl);
                                 return res.data || '';
                             });


### PR DESCRIPTION
I have some problem with request headers. By default it is `Accept: application/json, text/plain, */*` but I suppose it's wrong. This pull request set up accept header as `Accept: text/html`