### PR TITLE
Fix bug aria-describedby is overwritted by default value

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -413,6 +413,7 @@
                     applyAriaAttribute: function($dialog, attr, id, selector) {
                         if (id) {
                             $dialog.attr(attr, id);
+                            return;
                         }
 
                         if (selector) {


### PR DESCRIPTION
This PR is to fix the bug of setting ariaDescribedById,
The ariaDescribedById option user passed in would be overwritten by generated id.