### PR TITLE
changes close element to button with proper accessibility rules (Fixes Issue #511)

### DIFF
--- a/css/ngDialog.css
+++ b/css/ngDialog.css
@@ -102,6 +102,12 @@
   animation: ngdialog-fadeout 0.5s;
 }
 
+.ngdialog-close {
+  -webkit-appearance: none;
+  background: none;
+  border: none;
+}
+
 .ngdialog-close:before {
   font-family: 'Helvetica', Arial, sans-serif;
   content: '\00D7';

--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -519,7 +519,7 @@
                                 locals = setup.locals;
 
                             if (options.showClose) {
-                                template += '<div class="ngdialog-close"></div>';
+                                template += '<button aria-label="Dismiss" class="ngdialog-close"></button>';
                             }
 
                             var hasOverlayClass = options.overlay ? '' : ' ngdialog-no-overlay';


### PR DESCRIPTION
The close button is not appearing on screen readers because it is not marked up as an interactable element. 
- element changed to button
- aria-label set to "Dismiss" to avoid confusion with closing the tab, browser, or whole page. 
- css rules added to remove default browser styling of button elements

**Related issues**
https://github.com/likeastore/ngDialog/issues/511

This contribution is provided under the MIT License.