### PR TITLE
Fix for issue #520 where IE11 flashed up the modal after close

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -170,10 +170,22 @@
                         $rootScope.$broadcast('ngDialog.closing', $dialog, value);
                         dialogsCount = dialogsCount < 0 ? 0 : dialogsCount;
                         if (animationEndSupport && !options.disableAnimation) {
+			    var isIE = !!window.MSInputMethodContext && !!document.documentMode;
                             scope.$destroy();
-                            $dialog.unbind(animationEndEvent).bind(animationEndEvent, function () {
-                                privateMethods.closeDialogElement($dialog, value);
-                            }).addClass('ngdialog-closing');
+                            if (!isIE) {
+                                $dialog.unbind(animationEndEvent).bind(animationEndEvent, function () {
+                                        privateMethods.closeDialogElement($dialog, value);
+                                }).addClass('ngdialog-closing');
+                            }
+                            // Awful IE detection due to https://connect.microsoft.com/IE/feedbackdetail/view/1605631/animation-end-events-firing-late 
+                            else {
+                                $dialog.addClass('ngdialog-closing');
+                                var duration = window.getComputedStyle($dialog.find(".ngdialog-content")[0]).animationDuration,
+                                    dialogAnimationDuration = (0 < duration.indexOf("ms")) ? parseFloat(duration) : parseFloat(duration) * 1000;
+                                setTimeout(function () {
+                                    privateMethods.closeDialogElement($dialog, value);
+                                }, dialogAnimationDuration);                    
+                            }                        
                         } else {
                             scope.$destroy();
                             privateMethods.closeDialogElement($dialog, value);


### PR DESCRIPTION
Issue #520 is caused by an IE bug, which Microsoft do not intend to fix. This works around that by setting a manual timeout based on the animation duration configured for the modal element.

<!--
Note that leaving sections blank will make it difficult for us understand what this PR is for and it may be closed.
-->

**What issue is this PR resolving? Alternatively, please describe the bugfix/enhancement this PR aims to provide**
<!-- 
Provide a general description of the code changes in your pull
request. If bugs were fixed, please document the changes and why
they were introduced.

Please ensure that your PR contains test cases that cover all new
code and any changes to existing code. Without tests, your PR is
likely to be closed without merging.

If the build is not green, your PR may be closed without merging.

If you do not understand why the build is not green, please ask! We might be able to help.
-->

**Have you provided unit tests that either prove the bugfix or cover the enhancement?**

**Related issues**
<!--
Please review the (https://github.com/likeastore/ng-dialog/issues)
page, and link any issues that are addressed or related to this PR.
-->
