### PR TITLE
Fix Issue #537

### DIFF
--- a/example/browser-back-button/ui-router-1.0.0-rc.1.html
+++ b/example/browser-back-button/ui-router-1.0.0-rc.1.html
@@ -1,0 +1,121 @@
+ <!doctype html>
+<html ng-app="backButtonDemo">
+<head>
+    <meta charset="utf-8">
+    <title>ngDialog demo</title>
+    <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700,400italic' rel='stylesheet' type='text/css'>
+    <link rel="stylesheet" href="../../css/ngDialog.css">
+    <link rel="stylesheet" href="../../css/ngDialog-theme-default.css">
+    <link rel="stylesheet" href="../../css/ngDialog-theme-plain.css">
+    <link rel="stylesheet" href="../../css/ngDialog-custom-width.css">
+
+    <style>
+        a, button {
+            font: 14px 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+            display: block;
+            color: #333;
+            margin-bottom: 10px;
+        }
+
+        /* The following 'important' styles are just here to show off trapFocus */
+        button.ngdialog-button {
+            border: solid transparent 1px !important;
+        }
+
+        button.ngdialog-button:focus {
+            border: solid black 1px !important;
+        }
+
+        .ngdialog h2:focus { outline: none; }
+    </style>
+</head>
+<body>
+
+	<ui-view />
+
+    <!-- Templates -->
+
+    <script type="text/ng-template" id="home.html">
+		<h1> Home Page </h1>
+		<h1> Navigate to the about page </h1>
+		<button ui-sref="about"> ABOUT PAGE </button>
+    </script>
+
+    <script type="text/ng-template" id="about.html">
+    	<h1> About Page </h1>
+    	<p> {{ text }} </p>
+    	<button ui-sref="home"> HOME PAGE </button>
+    </script>
+
+    <script type="text/ng-template" id="resolveDialog">
+    	Sup?
+    	<div class="ngdialog-buttons">
+        	<button class="ngdialog-button ngdialog-button-primary" ng-click="confirm()"> Continue </button>
+        	<button class="ngdialog-button ngdialog-button-primary" ng-click="closeThisDialog()"> Go Back </button>
+        </div>
+    </script>
+
+    <!-- Scripts -->
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.0/angular.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-router/1.0.0-rc.1/angular-ui-router.min.js"></script>
+    <script>window.angular || document.write('<script src="../../bower_components/angular/angular.min.js">\x3C/script>')</script>
+    <script src="../../js/ngDialog.js"></script>
+
+    <!-- App -->
+    <script>
+    	angular.module('backButtonDemo', ['ngDialog', 'ui.router'])
+
+    	.config(function($urlMatcherFactoryProvider, $stateProvider){
+    		$urlMatcherFactoryProvider.strictMode(false);
+    		$stateProvider.state('home',
+    			{
+    				url: '',
+    				templateUrl: 'home.html'
+    		})
+    		.state('about',
+    			{
+    				url: '/about',
+    				templateUrl: 'about.html',
+    				controller: 'mainController',
+    				resolve:  {
+    					'RESOLVE_DATA' : function($q) {
+    						var defer = $q.defer();
+    						setTimeout(function() {
+    							defer.resolve('the data for this page resolves after 1ms');
+    						}, 1);
+  							return defer.promise;
+    					}
+    				}
+    		});
+    	})
+
+    	.run(function($rootScope) {
+    		$rootScope.$on('$locationChangeSuccess', function(){
+    			console.log('$locationChangeSuccess event fired');
+    		});
+    		$rootScope.$on('$stateChangeSuccess', function(){
+    			console.log('$stateChangeSuccess event fired');
+    		});
+    	})
+
+    	.controller('mainController', function($scope, RESOLVE_DATA, ngDialog, $state){
+    		$scope.text = RESOLVE_DATA;
+
+	        ngDialog.openConfirm({
+	            template: 'resolveDialog',
+	            className: 'ngdialog-theme-default',
+	            scope: $scope,
+	            closeByDocument: false,
+	            closeByEscape: false,
+	            showClose: false,
+	            closeByNavigation: true
+	        }).then(function(value) {
+	            return value;
+	        }, function(reason) {
+	            $state.go('home');
+	            return reason;
+	        });
+    	});
+    </script>
+</body>
+</html>

--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -37,6 +37,7 @@
     var openIdStack = [];
     var keydownIsBound = false;
     var openOnePerName = false;
+    var closeByNavigationDialogStack = [];
 
 
     m.provider('ngDialog', function () {
@@ -443,17 +444,23 @@
                     },
 
                     detectUIRouter: function() {
-                        //Detect if ui-router module is installed if not return false
-                        try {
-                            angular.module('ui.router');
-                            return true;
-                        } catch(err) {
-                            return false;
+                        // Detect if ui-router module is installed
+                        // Returns ui-router version string if installed
+                        // Otherwise false
+
+                        if ($injector.has('$transitions')) {
+                            // Only 1.0.0+ ui.router allows us to inject $transitions
+                            return '1.0.0+';
                         }
+                        else if ($injector.has('$state')) {
+                            // The legacy ui.router allows us to inject $state
+                            return 'legacy';
+                        }
+                        return false;
                     },
 
                     getRouterLocationEventName: function() {
-                        if(privateMethods.detectUIRouter()) {
+                        if (privateMethods.detectUIRouter()) {
                             return '$stateChangeStart';
                         }
                         return '$locationChangeStart';
@@ -685,11 +692,7 @@
                             }
 
                             if (options.closeByNavigation) {
-                                var eventName = privateMethods.getRouterLocationEventName();
-                                $rootScope.$on(eventName, function ($event) {
-                                    if (privateMethods.closeDialog($dialog) === false)
-                                        $event.preventDefault();
-                                });
+                                closeByNavigationDialogStack.push($dialog);
                             }
 
                             if (options.preserveFocus) {
@@ -868,6 +871,31 @@
                         }
                     }
                 );
+
+                // Listen to navigation events to close dialog
+                var uiRouterVersion = privateMethods.detectUIRouter();
+                if (uiRouterVersion === '1.0.0+') {
+                    var $transitions = $injector.get('$transitions');
+                    $transitions.onStart({}, function (trans) {
+                        while (closeByNavigationDialogStack.length > 0) {
+                            var toCloseDialog = closeByNavigationDialogStack.pop();
+                            if (privateMethods.closeDialog(toCloseDialog) === false) {
+                                return false;
+                            }
+                        }
+                    });
+                }
+                else {
+                    var eventName = uiRouterVersion === 'legacy' ? '$stateChangeStart' : '$locationChangeStart';
+                    $rootScope.$on(eventName, function ($event) {
+                        while (closeByNavigationDialogStack.length > 0) {
+                            var toCloseDialog = closeByNavigationDialogStack.pop();
+                            if (privateMethods.closeDialog(toCloseDialog) === false) {
+                                $event.preventDefault();
+                            }
+                        }
+                    });
+                }
 
                 return publicMethods;
             }];

--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -39,6 +39,8 @@
     var openOnePerName = false;
     var closeByNavigationDialogStack = [];
 
+    var UI_ROUTER_VERSION_LEGACY = 'legacy';
+    var UI_ROUTER_VERSION_ONE_PLUS = '1.0.0+';
 
     m.provider('ngDialog', function () {
         var defaults = this.defaults = {
@@ -450,11 +452,11 @@
 
                         if ($injector.has('$transitions')) {
                             // Only 1.0.0+ ui.router allows us to inject $transitions
-                            return '1.0.0+';
+                            return UI_ROUTER_VERSION_ONE_PLUS;
                         }
                         else if ($injector.has('$state')) {
                             // The legacy ui.router allows us to inject $state
-                            return 'legacy';
+                            return UI_ROUTER_VERSION_LEGACY;
                         }
                         return false;
                     },
@@ -874,7 +876,7 @@
 
                 // Listen to navigation events to close dialog
                 var uiRouterVersion = privateMethods.detectUIRouter();
-                if (uiRouterVersion === '1.0.0+') {
+                if (uiRouterVersion === UI_ROUTER_VERSION_ONE_PLUS) {
                     var $transitions = $injector.get('$transitions');
                     $transitions.onStart({}, function (trans) {
                         while (closeByNavigationDialogStack.length > 0) {
@@ -886,7 +888,7 @@
                     });
                 }
                 else {
-                    var eventName = uiRouterVersion === 'legacy' ? '$stateChangeStart' : '$locationChangeStart';
+                    var eventName = uiRouterVersion === UI_ROUTER_VERSION_LEGACY ? '$stateChangeStart' : '$locationChangeStart';
                     $rootScope.$on(eventName, function ($event) {
                         while (closeByNavigationDialogStack.length > 0) {
                             var toCloseDialog = closeByNavigationDialogStack.pop();

--- a/tests/protractor/closeByNavigation.js
+++ b/tests/protractor/closeByNavigation.js
@@ -1,0 +1,39 @@
+describe('ngDialog closeByNavigation', function () {
+
+    it('should close on state change with legacy ui-router', function () {
+        // Load page
+        browser.get('http://localhost:3000/example/browser-back-button/index.html');
+
+        // Click button to go to 'about' state
+        element(by.css('[ui-sref=about]')).click();
+
+        // Expect a visible dialog on the page
+        var EC = protractor.ExpectedConditions;
+        browser.wait(EC.visibilityOf(element(by.css('.ngdialog'))), 5000);
+
+        // Go back to 'home' state
+        browser.navigate().back();
+
+        // Expect there's no visible dialog on the page
+        browser.wait(EC.not(EC.presenceOf(element(by.css('.ngdialog')))), 5000);
+    });
+
+    it('should close on state change with legacy ui-router', function () {
+        // Load page
+        browser.get('http://localhost:3000/example/browser-back-button/ui-router-1.0.0-rc.1.html');
+
+        // Click button to go to 'about' state
+        element(by.css('[ui-sref=about]')).click();
+
+        // Expect a visible dialog on the page
+        var EC = protractor.ExpectedConditions;
+        browser.wait(EC.visibilityOf(element(by.css('.ngdialog'))), 5000);
+
+        // Go back to 'home' state
+        browser.navigate().back();
+
+        // Expect there's no visible dialog on the page
+        browser.wait(EC.not(EC.presenceOf(element(by.css('.ngdialog')))), 5000);
+    });
+
+});


### PR DESCRIPTION
<!--
Note that leaving sections blank will make it difficult for us understand what this PR is for and it may be closed.
-->
This is to fix the issue #537 closeByNavigation not working with Angular Ui-Router 1.0.0+.

Angular-ui-router 1.0.0+ doesn't broadcast an event at the $rootscope when there's a state change. However, we need to register a hook into their $transitions service so that we could be notified when there's a state change. 

My initial thought was to detect the version of angular-ui-router used and decide how are we going to be notified when there's a state change. Unfortunately, I wasn't able to get the version number from their APIs. However, I figured only the angular-ui-router 1.0.0+ allows us to inject a $transitions service while the legacy versions don't, so, I used this to decide how we listen to state change event.

Besides, I think the old way which attaches an listener function to $rootscope when an dialog is being open might introduce memory leak as the listener function would never be removed even when all dialogs are closed. 

**What issue is this PR resolving? Alternatively, please describe the bugfix/enhancement this PR aims to provide**
Issue #537 
<!-- 
Provide a general description of the code changes in your pull
request. If bugs were fixed, please document the changes and why
they were introduced.

Please ensure that your PR contains test cases that cover all new
code and any changes to existing code. Without tests, your PR is
likely to be closed without merging.

If the build is not green, your PR may be closed without merging.

If you do not understand why the build is not green, please ask! We might be able to help.
-->

**Have you provided unit tests that either prove the bugfix or cover the enhancement?**
Yes, I've added a protractor test

**Related issues**
<!--
Please review the (https://github.com/likeastore/ng-dialog/issues)
page, and link any issues that are addressed or related to this PR.
-->