### PR TITLE
Differentiate different body classes when multiple dialogs are open

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -35,6 +35,7 @@
     var forceElementsReload = { html: false, body: false };
     var scopes = {};
     var openIdStack = [];
+    var activeBodyClasses = [];
     var keydownIsBound = false;
     var openOnePerName = false;
 
@@ -207,11 +208,17 @@
                     closeDialogElement: function($dialog, value) {
                         var options = $dialog.data('$ngDialogOptions');
                         $dialog.remove();
-                        if (dialogsCount === 0) {
+
+                        activeBodyClasses.splice(activeBodyClasses.indexOf(options.bodyClassName), 1);
+                        if (activeBodyClasses.indexOf(options.bodyClassName) === -1) {
                             $elements.html.removeClass(options.bodyClassName);
                             $elements.body.removeClass(options.bodyClassName);
+                        }
+
+                        if (dialogsCount === 0) {
                             privateMethods.resetBodyPadding();
                         }
+
                         $rootScope.$broadcast('ngDialog.closed', $dialog, value);
                     },
 
@@ -655,6 +662,7 @@
                                 var widthDiffs = $window.innerWidth - $elements.body.prop('clientWidth');
                                 $elements.html.addClass(options.bodyClassName);
                                 $elements.body.addClass(options.bodyClassName);
+                                activeBodyClasses.push(options.bodyClassName);
                                 var scrollBarWidth = widthDiffs - ($window.innerWidth - $elements.body.prop('clientWidth'));
                                 if (scrollBarWidth > 0) {
                                     privateMethods.setBodyPadding(scrollBarWidth);

--- a/tests/unit/ngDialog.js
+++ b/tests/unit/ngDialog.js
@@ -376,4 +376,60 @@ describe('ngDialog', function () {
     });
   });
 
+  describe('body classes should be applied / removed correctly', function () {
+    var elm, first, second, ngDialog, flush;
+
+    beforeEach(inject(function (_ngDialog_, $timeout, $document) {
+      ngDialog = _ngDialog_
+
+      first = ngDialog.open({
+        bodyClassName: 'ngdialog-first'
+      });
+
+      $timeout.flush();
+
+      second = ngDialog.open({
+        bodyClassName: 'ngdialog-second'
+      });
+
+      $timeout.flush();
+
+      elm = angular.element($document.find('body'));
+
+      flush = function () {
+        [].slice.call(
+          $document.find('body').children()
+        )
+        .map(angular.element)
+        .forEach(function (elm) {
+          if (elm.hasClass('ngdialog')) {
+            // yuck
+            elm.triggerHandler('animationend');
+          }
+        });
+      };
+    }));
+
+    it('should have two body classes applied', function () {
+      expect(elm.hasClass('ngdialog-first')).toEqual(true);
+      expect(elm.hasClass('ngdialog-second')).toEqual(true);
+    });
+
+    it('should properly remove one body class', inject(function ($document) {
+      first.close();
+      flush();
+
+      expect(elm.hasClass('ngdialog-second')).toEqual(true);
+      expect(elm.hasClass('ngdialog-first')).toEqual(false);
+    }));
+
+    it('should properly remove all classes on closeAll', inject(function ($document) {
+      ngDialog.closeAll();
+      flush();
+
+      expect(elm.hasClass('ngdialog-second')).toEqual(false);
+      expect(elm.hasClass('ngdialog-first')).toEqual(false);
+    }));
+  });
+
 });

--- a/tests/unit/ngDialog.js
+++ b/tests/unit/ngDialog.js
@@ -415,21 +415,21 @@ describe('ngDialog', function () {
       expect(elm.hasClass('ngdialog-second')).toEqual(true);
     });
 
-    it('should properly remove one body class', inject(function ($document) {
+    it('should properly remove one body class', function () {
       first.close();
       flush();
 
       expect(elm.hasClass('ngdialog-second')).toEqual(true);
       expect(elm.hasClass('ngdialog-first')).toEqual(false);
-    }));
+    });
 
-    it('should properly remove all classes on closeAll', inject(function ($document) {
+    it('should properly remove all classes on closeAll', function () {
       ngDialog.closeAll();
       flush();
 
       expect(elm.hasClass('ngdialog-second')).toEqual(false);
       expect(elm.hasClass('ngdialog-first')).toEqual(false);
-    }));
+    });
   });
 
 });


### PR DESCRIPTION
**What issue is this PR resolving? Alternatively, please describe the bugfix/enhancement this PR aims to provide**

* When you open multiple dialogs with different body classes (in options), you'll append two different classes to the body (e.g. ngdialog-open [latter] and ngdialog-edit-open) When you close the top dialog, both classes persist but only ngdialog-edit-open should be there.

* This PR resolves this by maintaining which body classes are active and removing the necessary classes from the DOM when necessary.

**Have you provided unit tests that either prove the bugfix or cover the enhancement?**
* make sure that opening two dialogs append two classes
* closing one dialog will remove one class but keep the other
* closeAll will remove all classes

**Related issues**
* No related issues
