### PR TITLE
fix for Scrollbars not clickable on overflow

### DIFF
--- a/css/ngDialog.css
+++ b/css/ngDialog.css
@@ -57,6 +57,10 @@
   right: 0;
   bottom: 0;
   left: 0;
+  /* fix for Scrollbars not clickable on overflow #552 */
+  background: rgba(0, 0, 0, 0.4); 
+  animation: ngdialog-fadein 0.5s;
+  /* end fix for Scrollbars not clickable on overflow #552 */
 }
 
 .ngdialog.ngdialog-disabled-animation,
@@ -68,7 +72,6 @@
 
 .ngdialog-overlay {
   position: fixed;
-  background: rgba(0, 0, 0, 0.4);
   top: 0;
   right: 0;
   bottom: 0;
@@ -76,6 +79,10 @@
   -webkit-backface-visibility: hidden;
   -webkit-animation: ngdialog-fadein 0.5s;
   animation: ngdialog-fadein 0.5s;
+  /* fix for Scrollbars not clickable on overflow #552 */
+  margin-right: 15px;
+  background: transparent;
+  /* end fix for Scrollbars not clickable on overflow #552 */
 }
 
 .ngdialog-no-overlay {


### PR DESCRIPTION
Make ngdialog-overlay background transparent and pass this background opacity to ngdialog. 
ngdialog-overlay have now a 15px margin-right to allow clickeable scrollbar.

--
Regards,
www.dpicode.com

<!--
Note that leaving sections blank will make it difficult for us understand what this PR is for and it may be closed.
-->

**What issue is this PR resolving? Alternatively, please describe the bugfix/enhancement this PR aims to provide**
<!-- 
Provide a general description of the code changes in your pull
request. If bugs were fixed, please document the changes and why
they were introduced.

Please ensure that your PR contains test cases that cover all new
code and any changes to existing code. Without tests, your PR is
likely to be closed without merging.

If the build is not green, your PR may be closed without merging.

If you do not understand why the build is not green, please ask! We might be able to help.
-->

**Have you provided unit tests that either prove the bugfix or cover the enhancement?**

**Related issues**
<!--
Please review the (https://github.com/likeastore/ng-dialog/issues)
page, and link any issues that are addressed or related to this PR.
-->
