### PR TITLE
Fix getActiveDialog to accept different appendTo values

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -387,14 +387,22 @@
                     },
 
                     getActiveDialog: function () {
-                        var dialogs = document.querySelectorAll('.ngdialog');
-
-                        if (dialogs.length === 0) {
+                        if (openIdStack.length === 0) {
                             return null;
                         }
-
-                        // TODO: This might be incorrect if there are a mix of open dialogs with different 'appendTo' values
-                        return $el(dialogs[dialogs.length - 1]);
+                        var dialogs;
+                        return openIdStack.map(function (id) {
+                            return $el('#' + id);
+                        }).reduce(function (a, b) {
+                            var aZIndex = parseInt(a.css('z-index'));
+                            var bZIndex = parseInt(b.css('z-index'));
+                            if (aZIndex === bZIndex) {
+                                var dialogs = dialogs || $el('.ngdialog');
+                                return (dialogs.index(a) > dialogs.index(b)) ? a : b;
+                            } else {
+                                return (aZIndex > bZIndex) ? a : b;
+                            }
+                        });
                     },
 
                     applyAriaAttributes: function ($dialog, options) {


### PR DESCRIPTION
The getActiveDialog private function is currently used to handle the TAB key in case trapFocus is true. The function returns the last '.ngdialog' in the DOM, which is normally the active dialog, but as noted in a comment in the source code, this doesn't work in case of mixed 'appendTo' values. You might be opening a second dialog somewhere before in the DOM which is actually the active one, because due to a higher z-index value it's the one being shown on the top.

This caused the TAB key not to work properly in those cases of mixed 'appendTo' values. Here's a demo of the problem: https://jsfiddle.net/r6fr5wz0/
Click on "open second dialog" and then press TAB. The result will be that the focus goes back to the first dialog (as it is the active one according to getActiveDialog for being the latest in the DOM) while the expected behaviour would be to stay in the second one.

My PR fixes this problem. It goes over the openIdStack getting the highest z-index. In case it's the same among two dialogs, then it checks the order in the DOM. This makes getActiveDialog always return the topmost dialog.

The previous demo with my PR applied: https://jsfiddle.net/55jwo3sb/