### PR TITLE
fixing #568 by using boundingrect to determine visibility

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -376,10 +376,10 @@
                         var visibleFocusableElements = [];
 
                         for (var i = 0; i < els.length; i++) {
-                            var el = els[i];
+                            var clientRect = els[i].getBoundingClientRect();
 
-                            if (el.offsetWidth > 0 || el.offsetHeight > 0) {
-                                visibleFocusableElements.push(el);
+                            if (clientRect.height > 0 || clientRect.width > 0) {
+                                visibleFocusableElements.push(els[i]);
                             }
                         }
 

--- a/tests/unit/ngDialog.js
+++ b/tests/unit/ngDialog.js
@@ -432,4 +432,35 @@ describe('ngDialog', function () {
     });
   });
 
+  describe('with trapped focus', function () {
+    var document, elm;
+
+    beforeEach(inject(function (ngDialog, $timeout, $document) {
+      var id = ngDialog.open({
+        template: '<svg><rect id=test1 width=10 height=10 tabindex=0></rect></svg><a id=test2 href="#"></div>',
+        trapFocus: true,
+        plain: true,
+        showClose: false
+      }).id;
+      $timeout.flush();
+
+      document = $document[0];
+      elm = angular.element(document.getElementById(id));
+    }));
+
+    it('should be able to focus SVG elements', function () {
+      expect(document.activeElement.id).toBe('test1');
+    });
+
+    it('should let the browser handle tab key event after SVG is focused', function () {
+      var preventDefaultSpy = jasmine.createSpy('preventDefaultSpy');
+      var stopPropagationSpy = jasmine.createSpy('stopPropagationSpy');
+
+      // pressing TAB
+      elm.triggerHandler({type: 'keydown', keyCode: 9, preventDefault: preventDefaultSpy, stopPropagation: stopPropagationSpy});
+
+      expect(preventDefaultSpy).not.toHaveBeenCalled();
+      expect(stopPropagationSpy).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
**What issue is this PR resolving? Alternatively, please describe the bugfix/enhancement this PR aims to provide**
This PR is fixing #568 by making inline SVG elements focusable when we use 'trapFocus'.

**Have you provided unit tests that either prove the bugfix or cover the enhancement?**
👍 

**Related issues**
None AFAIK
