### PR TITLE
Fixes for mouse scroll for firefox.

### DIFF
--- a/css/ngDialog-theme-default.css
+++ b/css/ngDialog-theme-default.css
@@ -78,6 +78,7 @@
   padding: 1em;
   position: relative;
   width: 450px;
+  z-index: 1  
 }
 
 .ngdialog.ngdialog-theme-default .ngdialog-close {


### PR DESCRIPTION
Model overlay and Model content z-index are at same, which disallows the mouse scroll. 
Updating on the z-index fixes the mouse scroll on fire fox.

Thanks,

<!--
Note that leaving sections blank will make it difficult for us understand what this PR is for and it may be closed.
-->

**What issue is this PR resolving? Alternatively, please describe the bugfix/enhancement this PR aims to provide**
<!-- 
Provide a general description of the code changes in your pull
request. If bugs were fixed, please document the changes and why
they were introduced.

Please ensure that your PR contains test cases that cover all new
code and any changes to existing code. Without tests, your PR is
likely to be closed without merging.

If the build is not green, your PR may be closed without merging.

If you do not understand why the build is not green, please ask! We might be able to help.
-->

**Have you provided unit tests that either prove the bugfix or cover the enhancement?**

**Related issues**
<!--
Please review the (https://github.com/likeastore/ng-dialog/issues)
page, and link any issues that are addressed or related to this PR.
-->
